### PR TITLE
Missing pixels fixed

### DIFF
--- a/FeatureEngineering/Advanced/calculate_advanced_features.py
+++ b/FeatureEngineering/Advanced/calculate_advanced_features.py
@@ -133,11 +133,10 @@ def main(watershed_name):
     with rasterio.open(dem_file) as src:
         dem = src.read(1).astype(np.float64)
         profile = src.profile
-        nodata_mask = dem > 1e10
-        dem[nodata_mask] = np.nan
 
     # Mask of pixels inside the watershed (used for boundary NaN filling)
-    watershed_mask = ~nodata_mask
+    # Outside-watershed pixels are stored as NaN in the GEE-exported DEM
+    watershed_mask = ~np.isnan(dem)
 
     # 1. Aspect
     print("Calculating aspect...")

--- a/FeatureEngineering/Advanced/calculate_advanced_features.py
+++ b/FeatureEngineering/Advanced/calculate_advanced_features.py
@@ -13,7 +13,7 @@ Adds 11 new features:
 
 import rasterio
 import numpy as np
-from scipy.ndimage import generic_filter, uniform_filter
+from scipy.ndimage import generic_filter, uniform_filter, distance_transform_edt
 import sys
 from pathlib import Path
 
@@ -79,6 +79,24 @@ def calculate_tri(elevation):
     return tri.astype(np.float32)
 
 
+def fill_boundary_nans(data, watershed_mask):
+    """
+    Fill NaN pixels that are inside the watershed but got NaN'd due to edge
+    effects in gradient or windowed filter operations. Uses nearest-neighbor
+    interpolation from surrounding valid pixels.
+
+    watershed_mask: boolean array, True where DEM is valid (inside watershed)
+    """
+    invalid = np.isnan(data) & watershed_mask
+    n_invalid = int(invalid.sum())
+    if n_invalid > 0:
+        _, nearest = distance_transform_edt(
+            np.isnan(data), return_distances=True, return_indices=True
+        )
+        data[invalid] = data[nearest[0][invalid], nearest[1][invalid]]
+    return data, n_invalid
+
+
 def calculate_std_dev_multiwindow(data, window_sizes=[3, 5, 9]):
     """Calculate standard deviation at multiple window sizes"""
     results = {}
@@ -118,9 +136,14 @@ def main(watershed_name):
         nodata_mask = dem > 1e10
         dem[nodata_mask] = np.nan
 
+    # Mask of pixels inside the watershed (used for boundary NaN filling)
+    watershed_mask = ~nodata_mask
+
     # 1. Aspect
     print("Calculating aspect...")
     aspect = calculate_aspect(dem)
+    aspect, n = fill_boundary_nans(aspect, watershed_mask)
+    if n: print(f"  (filled {n:,} boundary NaN pixels)")
     with rasterio.open(output_dir / "aspect.tif", 'w', **profile) as dst:
         dst.write(aspect, 1)
     print("✓ aspect.tif")
@@ -128,6 +151,10 @@ def main(watershed_name):
     # 2. Curvature
     print("Calculating curvature...")
     curv_prof, curv_plan = calculate_curvature(dem)
+    curv_prof, n = fill_boundary_nans(curv_prof, watershed_mask)
+    if n: print(f"  (filled {n:,} boundary NaN pixels in profile curvature)")
+    curv_plan, n = fill_boundary_nans(curv_plan, watershed_mask)
+    if n: print(f"  (filled {n:,} boundary NaN pixels in plan curvature)")
     with rasterio.open(output_dir / "curvature_profile.tif", 'w', **profile) as dst:
         dst.write(curv_prof, 1)
     with rasterio.open(output_dir / "curvature_plan.tif", 'w', **profile) as dst:
@@ -151,6 +178,8 @@ def main(watershed_name):
     # 5. TRI
     print("Calculating TRI...")
     tri = calculate_tri(dem)
+    tri, n = fill_boundary_nans(tri, watershed_mask)
+    if n: print(f"  (filled {n:,} boundary NaN pixels)")
     with rasterio.open(output_dir / "tri.tif", 'w', **profile) as dst:
         dst.write(tri, 1)
     print("✓ tri.tif")
@@ -160,6 +189,8 @@ def main(watershed_name):
     elev_std = calculate_std_dev_multiwindow(dem, [3, 9])
     for window, data in elev_std.items():
         size = window.split('_')[1]
+        data, n = fill_boundary_nans(data, watershed_mask)
+        if n: print(f"  (filled {n:,} boundary NaN pixels in elev_std_{size}x{size})")
         with rasterio.open(output_dir / f"elev_std_{size}x{size}.tif", 'w', **profile) as dst:
             dst.write(data, 1)
         print(f"✓ elev_std_{size}x{size}.tif")
@@ -174,6 +205,8 @@ def main(watershed_name):
         slope_std = calculate_std_dev_multiwindow(slope, [3, 9])
         for window, data in slope_std.items():
             size = window.split('_')[1]
+            data, n = fill_boundary_nans(data, watershed_mask)
+            if n: print(f"  (filled {n:,} boundary NaN pixels in slope_std_{size}x{size})")
             with rasterio.open(output_dir / f"slope_std_{size}x{size}.tif", 'w', **profile) as dst:
                 dst.write(data, 1)
             print(f"✓ slope_std_{size}x{size}.tif")

--- a/FeatureEngineering/Soil/calculate_soil_features.py
+++ b/FeatureEngineering/Soil/calculate_soil_features.py
@@ -180,7 +180,7 @@ def process_soil_features(watershed_name):
         print("\nNo soil features were processed. Check that input files exist.")
         sys.exit(1)
 
-    print("\nNext step: Add soil features to FeatureStacking/stack_features.py")
+    print("\nNext step: Run stack_features.py to combine all 23 features")
 
 
 if __name__ == "__main__":

--- a/FeatureStacking/stack_features.py
+++ b/FeatureStacking/stack_features.py
@@ -14,7 +14,7 @@ def get_repo_root():
     return Path(__file__).resolve().parents[1]
 
 def stack_features(watershed_name):
-    """Stack all 20 features into one multi-band raster"""
+    """Stack all 23 features into one multi-band raster"""
 
     # Use absolute path from home directory
     repo_root = get_repo_root()

--- a/ModelTraining/predict_meadows.py
+++ b/ModelTraining/predict_meadows.py
@@ -154,7 +154,7 @@ def main(watershed_name, model_file="xgboost_model.pkl"):
     print(f"\nOutput: {output_path}")
     print(f"\nFinal output file: {output_path.name}")
     print("\nNext steps:")
-    print(f"  1. Upload {watershed_name}_meadow_probability.tif to Google Earth Engine")
+    print(f"  1. Upload {output_path.name} to Google Earth Engine")
     print("  2. Create GEE app to visualize results")
 
 if __name__ == "__main__":

--- a/TauDEM/run_taudem_workflow.py
+++ b/TauDEM/run_taudem_workflow.py
@@ -13,6 +13,8 @@ Output directory will be automatically created as: TIF_Output/<watershed_name>/
 import subprocess
 import sys
 import os
+import numpy as np
+import rasterio
 from pathlib import Path
 
 def run_cmd(cmd, description):
@@ -42,6 +44,50 @@ def extract_watershed_name(input_dem):
     """
     return Path(input_dem).stem
 
+def fix_stream_pixel_distances(output_dir, base):
+    """
+    TauDEM's dinfdistdown outputs NoData for pixels that lie on the stream
+    network itself (where _src.tif == 1), because the downslope distance is
+    undefined when you are already at the stream.
+
+    This causes a gap of missing pixels along every stream in the final
+    meadow probability output — predict_meadows.py masks out any pixel where
+    a feature value is below -1e30, which catches TauDEM's NoData sentinel
+    (~-3.4e38).
+
+    The correct value for stream pixels is 0 — they are literally zero distance
+    from the stream. This function replaces those NoData values with 0 so that
+    stream-adjacent and riparian pixels are not incorrectly dropped from
+    the prediction.
+    """
+    stream_file = os.path.join(output_dir, f"{base}_src.tif")
+    distance_files = ["dd_s.tif", "dd_h.tif", "dd_v.tif"]
+
+    print(f"\n{'='*60}")
+    print("Fixing NoData in stream distance rasters")
+    print(f"{'='*60}")
+
+    with rasterio.open(stream_file) as src:
+        stream_mask = src.read(1) == 1
+
+    print(f"Stream pixels identified: {np.sum(stream_mask):,}")
+
+    for fname in distance_files:
+        fpath = os.path.join(output_dir, fname)
+        with rasterio.open(fpath) as src:
+            profile = src.profile.copy()
+            data = src.read(1)
+
+        nodata_pixels = stream_mask & (data < -1e10)
+        n_fixed = int(np.sum(nodata_pixels))
+        data[nodata_pixels] = 0.0
+
+        with rasterio.open(fpath, "w", **profile) as dst:
+            dst.write(data, 1)
+
+        print(f"  ✓ {fname}: replaced {n_fixed:,} NoData stream pixels with 0")
+
+
 def main(input_dem):
     """Run full TauDEM workflow"""
 
@@ -61,9 +107,19 @@ def main(input_dem):
     # Get base name without extension (for TauDEM internal files)
     base = Path(input_dem).stem
 
-    # Number of cores (adjust based on your CPU)
-    # Using 4 out of 8 available cores - good balance of speed and system responsiveness
-    ncores = 4
+    # Ask user how many cores to use for MPI parallelism
+    available_cores = os.cpu_count() or 4
+    print(f"\nYour machine has {available_cores} CPU cores available.")
+    print("More cores = faster TauDEM processing.")
+    print("Recommended: leave at least 2 cores free for the OS.")
+    while True:
+        try:
+            ncores = int(input(f"How many cores should TauDEM use? [1-{available_cores}]: "))
+            if 1 <= ncores <= available_cores:
+                break
+            print(f"  Please enter a number between 1 and {available_cores}.")
+        except ValueError:
+            print("  Please enter a valid number.")
 
     print(f"\n{'='*60}")
     print(f"TauDEM Workflow - {watershed_name}")
@@ -129,7 +185,13 @@ def main(input_dem):
         f"mpiexec -n {ncores} dinfdistdown -ang {out(base + '_ang.tif')} -fel {out(base + '_filled.tif')} -src {out(base + '_src.tif')} -dd {out('dd_v.tif')} -m ave v",
         "Step 7c: Distance to stream (vertical)"
     )
-    
+
+    # Step 8: Fix NoData in stream distance rasters
+    # dinfdistdown outputs NoData for pixels ON the stream network. Those pixels
+    # are dropped by predict_meadows.py, creating visible gaps along every stream
+    # in the final output. The correct value is 0 (zero distance from the stream).
+    fix_stream_pixel_distances(output_dir, base)
+
     print(f"\n{'='*60}")
     print(f"TauDEM workflow completed successfully!")
     print(f"{'='*60}")

--- a/TauDEM/run_taudem_workflow.py
+++ b/TauDEM/run_taudem_workflow.py
@@ -15,6 +15,7 @@ import sys
 import os
 import numpy as np
 import rasterio
+from scipy.ndimage import distance_transform_edt
 from pathlib import Path
 
 def run_cmd(cmd, description):
@@ -44,48 +45,45 @@ def extract_watershed_name(input_dem):
     """
     return Path(input_dem).stem
 
-def fix_stream_pixel_distances(output_dir, base):
+def fix_distance_rasters(output_dir):
     """
-    TauDEM's dinfdistdown outputs NoData for pixels that lie on the stream
-    network itself (where _src.tif == 1), because the downslope distance is
-    undefined when you are already at the stream.
+    TauDEM's dinfdistdown leaves invalid values (nodata sentinel ~-3.4e38 and
+    Inf) in the distance rasters for pixels where it cannot determine a valid
+    downslope flow path — typically at watershed boundary edges and flow
+    divides. These invalid pixels are dropped by predict_meadows.py, creating
+    gaps in the final output.
 
-    This causes a gap of missing pixels along every stream in the final
-    meadow probability output — predict_meadows.py masks out any pixel where
-    a feature value is below -1e30, which catches TauDEM's NoData sentinel
-    (~-3.4e38).
-
-    The correct value for stream pixels is 0 — they are literally zero distance
-    from the stream. This function replaces those NoData values with 0 so that
-    stream-adjacent and riparian pixels are not incorrectly dropped from
-    the prediction.
+    This function fills those invalid pixels using nearest-neighbor
+    interpolation from surrounding valid pixels, recovering ~1.4M pixels
+    that would otherwise be missing from the prediction.
     """
-    stream_file = os.path.join(output_dir, f"{base}_src.tif")
     distance_files = ["dd_s.tif", "dd_h.tif", "dd_v.tif"]
 
     print(f"\n{'='*60}")
-    print("Fixing NoData in stream distance rasters")
+    print("Fixing invalid pixels in stream distance rasters")
     print(f"{'='*60}")
-
-    with rasterio.open(stream_file) as src:
-        stream_mask = src.read(1) == 1
-
-    print(f"Stream pixels identified: {np.sum(stream_mask):,}")
 
     for fname in distance_files:
         fpath = os.path.join(output_dir, fname)
         with rasterio.open(fpath) as src:
             profile = src.profile.copy()
-            data = src.read(1)
+            data = src.read(1).astype(np.float32)
 
-        nodata_pixels = stream_mask & (data < -1e10)
-        n_fixed = int(np.sum(nodata_pixels))
-        data[nodata_pixels] = 0.0
+        invalid = np.isnan(data) | np.isinf(data) | (data < -1e10)
+        n_invalid = int(invalid.sum())
+
+        if n_invalid > 0:
+            # distance_transform_edt returns the indices of the nearest valid
+            # pixel for every invalid pixel — fill from those neighbours
+            _, nearest = distance_transform_edt(
+                invalid, return_distances=True, return_indices=True
+            )
+            data[invalid] = data[nearest[0][invalid], nearest[1][invalid]]
 
         with rasterio.open(fpath, "w", **profile) as dst:
             dst.write(data, 1)
 
-        print(f"  ✓ {fname}: replaced {n_fixed:,} NoData stream pixels with 0")
+        print(f"  ✓ {fname}: filled {n_invalid:,} invalid pixels via nearest-neighbour")
 
 
 def main(input_dem):
@@ -186,11 +184,11 @@ def main(input_dem):
         "Step 7c: Distance to stream (vertical)"
     )
 
-    # Step 8: Fix NoData in stream distance rasters
-    # dinfdistdown outputs NoData for pixels ON the stream network. Those pixels
-    # are dropped by predict_meadows.py, creating visible gaps along every stream
-    # in the final output. The correct value is 0 (zero distance from the stream).
-    fix_stream_pixel_distances(output_dir, base)
+    # Step 8: Fix invalid pixels in stream distance rasters
+    # dinfdistdown leaves nodata sentinels (~-3.4e38) and Inf values for pixels
+    # where it cannot compute a valid downslope path (boundary edges, flow divides).
+    # These are filled via nearest-neighbor interpolation so no pixels are dropped.
+    fix_distance_rasters(output_dir)
 
     print(f"\n{'='*60}")
     print(f"TauDEM workflow completed successfully!")

--- a/Wetlands/prepare_training_data.py
+++ b/Wetlands/prepare_training_data.py
@@ -339,7 +339,7 @@ def main(watershed_name):
     print(f"  - Training CSV: {training_csv}")
     print(f"\nNext: Retrain model with real wetland data")
     print(f"  cd {get_repo_root() / 'ModelTraining'}")
-    print(f"  python train_random_forest.py {watershed_name}")
+    print(f"  python train_xgboost.py {watershed_name}")
 
     # Clean up wetland mask
     print("\nCleaning up intermediate files...")

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -179,9 +179,9 @@ def main(input_dem):
     print(f"  ✓ features_stacked.tif (23-band multi-band raster)")
     print(f"  ✓ training_data_real.csv")
     print(f"  ✓ xgboost_model.pkl (trained model)")
-    print(f"  ✓ {watershed_name}_meadow_probability.tif (FINAL OUTPUT)")
+    print(f"  ✓ {watershed_name}_xgboost_model_probability.tif (FINAL OUTPUT)")
     print(f"\nNext steps:")
-    print(f"  1. Upload {watershed_name}_meadow_probability.tif to Google Earth Engine")
+    print(f"  1. Upload {watershed_name}_xgboost_model_probability.tif to Google Earth Engine")
     print(f"  2. Run GEE/MeadowVisualization.js for interactive map")
     print(f"{'='*70}\n")
 


### PR DESCRIPTION
Fixes two sources of missing pixels in the final meadow probability raster:                                                   
                                                                           
  1. TauDEM stream distance rasters (dd_s, dd_h, dd_v)                     
  dinfdistdown leaves nodata sentinels and Inf values for pixels where it
  can't trace a downslope path (boundary edges, flow divides). Added       
  fix_distance_rasters() in run_taudem_workflow.py to fill these via
  nearest-neighbor interpolation after TauDEM runs, recovering ~1.4M       
  pixels.                                                   

  2. Terrain edge features (aspect, curvature, TRI, std devs)              
  np.gradient and generic_filter propagate NaN 1-2 pixels inward from the
  watershed boundary, dropping a uniform ring of pixels. Added             
  fill_boundary_nans() in calculate_advanced_features.py to fill affected
  pixels after each computation.                                           
                                                            
  Both fixes use scipy.ndimage.distance_transform_edt for nearest-neighbor 
  interpolation. No pixels are dropped from the prediction.


Closes #88 