### PR TITLE
Hyperparameter tuning

### DIFF
--- a/FeatureEngineering/Advanced/calculate_advanced_features.py
+++ b/FeatureEngineering/Advanced/calculate_advanced_features.py
@@ -134,9 +134,14 @@ def main(watershed_name):
         dem = src.read(1).astype(np.float64)
         profile = src.profile
 
+    # Outside-watershed pixels may be encoded as NaN, large positive, or large
+    # negative depending on GEE export settings and TauDEM version. Normalize
+    # all nodata to NaN so gradient/filter operations propagate correctly.
+    dem_nodata = np.isnan(dem) | (dem > 1e10) | (dem < -1e10)
+    dem[dem_nodata] = np.nan
+
     # Mask of pixels inside the watershed (used for boundary NaN filling)
-    # Outside-watershed pixels are stored as NaN in the GEE-exported DEM
-    watershed_mask = ~np.isnan(dem)
+    watershed_mask = ~dem_nodata
 
     # 1. Aspect
     print("Calculating aspect...")

--- a/ModelTraining/train_xgboost.py
+++ b/ModelTraining/train_xgboost.py
@@ -4,6 +4,7 @@ Train XGBoost model for meadow detection
 Mirrors train_random_forest.py for direct comparison
 """
 
+import json
 import numpy as np
 import pandas as pd
 from xgboost import XGBClassifier
@@ -82,6 +83,36 @@ def train_model(features, labels, watershed_name):
     pos = int(np.sum(y_train == 1))
     scale_pos_weight = neg / pos
 
+    # Load per-watershed hyperparameters if available (written by xgboost_gridsearch.py)
+    # Fall back to Bear Creek defaults if not found
+    output_dir = get_repo_root() / "GEE" / "TIF_Output" / watershed_name
+    params_path = output_dir / "best_params.json"
+    default_params = {
+        "n_estimators": 200,
+        "max_depth": 8,
+        "learning_rate": 0.05,
+        "subsample": 0.8,
+        "colsample_bytree": 0.6,
+        "gamma": 0.5,
+        "reg_alpha": 0,
+        "reg_lambda": 2.0,
+        "min_child_weight": 1,
+    }
+    if params_path.exists():
+        with open(params_path) as f:
+            tuned_params = json.load(f)
+        print(f"\nLoading tuned hyperparameters from: {params_path}")
+        xgb_params = {**default_params, **tuned_params}
+        params_source = "tuned (per-watershed)"
+    else:
+        print(f"\nNo tuned hyperparameters found — using Bear Creek defaults.")
+        xgb_params = default_params.copy()
+        params_source = "default (Bear Creek)"
+
+    # scale_pos_weight is always computed dynamically from class distribution
+    xgb_params["scale_pos_weight"] = round(scale_pos_weight, 4)
+    xgb_params["random_state"] = 42
+
     with mlflow.start_run(run_name=watershed_name):
 
         # ---- tags -------------------------------------------------------
@@ -89,6 +120,7 @@ def train_model(features, labels, watershed_name):
             "watershed": watershed_name,
             "model_type": "XGBoost",
             "label_source": "real",
+            "params_source": params_source,
         })
 
         # ---- data params ------------------------------------------------
@@ -107,26 +139,10 @@ def train_model(features, labels, watershed_name):
         })
 
         # ---- model training ---------------------------------------------
-        print(f"\nTraining XGBoost...")
-        print(f"  - n_estimators:     200")
-        print(f"  - max_depth:        6")
-        print(f"  - learning_rate:    0.1")
-        print(f"  - scale_pos_weight: {scale_pos_weight:.1f} (handles 1:{int(scale_pos_weight)} imbalance)")
-        print(f"  - random_state:     42")
-
-        xgb_params = {
-          "n_estimators": 200,
-          "max_depth": 8,
-          "learning_rate": 0.05,
-          "subsample": 0.8,
-          "colsample_bytree": 0.6,
-          "scale_pos_weight": round(scale_pos_weight, 4),  # dynamic, not hardcoded 3
-          "gamma": 0.5,
-          "reg_alpha": 0,
-          "reg_lambda": 2.0,
-          "min_child_weight": 1,
-          "random_state": 42,
-        }
+        print(f"\nTraining XGBoost ({params_source} parameters)...")
+        for k, v in sorted(xgb_params.items()):
+            print(f"  - {k}: {v}")
+        print()
         mlflow.log_params(xgb_params)
 
         xgb = XGBClassifier(

--- a/ModelTraining/xgboost_gridsearch.py
+++ b/ModelTraining/xgboost_gridsearch.py
@@ -1,23 +1,17 @@
 #!/usr/bin/env python3
 """
 Randomized hyperparameter search for XGBoost meadow detection model
-Uses 10k samples for speed, then reports best parameters to use in train_xgboost.py
 
-NOTE FOR NEW USERS:
-This script is NOT part of the main production pipeline (run_pipeline.py).
-It is a standalone tuning utility used to find the best hyperparameters for XGBoost.
+This script is called automatically by run_pipeline.py before training to find
+the best hyperparameters for each individual watershed. Results are saved to
+best_params.json in the watershed output directory, which train_xgboost.py
+reads automatically.
 
-How to use it:
-    1. Run this script on a watershed to search across many parameter combinations:
-           python xgboost_gridsearch.py <watershed_name>
-    2. It will print the best parameters found.
-    3. Copy those parameters manually into train_xgboost.py to use them in production.
-
-This search runs on a 10k sample subset for speed. Once good parameters are found
-they should be locked into train_xgboost.py — do not run this script on every
-pipeline run, only when you want to re-tune the model.
+Can also be run standalone:
+    python xgboost_gridsearch.py <watershed_name>
 """
 
+import json
 import numpy as np
 import pandas as pd
 from xgboost import XGBClassifier
@@ -93,7 +87,7 @@ def main(watershed_name):
     print("  - 100 random combinations")
     print("  - 5-fold cross-validation")
     print("  - Scoring: AUC")
-    print("  - This may take a few minutes...\n")
+    print("  - This may take ~1 minute...\n")
 
     search = RandomizedSearchCV(
         estimator=base_model,
@@ -146,12 +140,17 @@ def main(watershed_name):
         for k, v in sorted(params.items()):
             print(f"   {k:25s}: {v}")
 
+    # Save best params to JSON for train_xgboost.py to pick up automatically
+    output_dir = get_repo_root() / "GEE" / "TIF_Output" / watershed_name
+    params_path = output_dir / "best_params.json"
+    # Don't save scale_pos_weight — train_xgboost.py computes it dynamically
+    params_to_save = {k: v for k, v in search.best_params_.items() if k != "scale_pos_weight"}
+    with open(params_path, "w") as f:
+        json.dump(params_to_save, f, indent=2)
     print(f"\n{'='*60}")
-    print("Copy these best parameters into train_xgboost.py:")
+    print(f"Best parameters saved to: {params_path}")
+    print("train_xgboost.py will use these automatically.")
     print(f"{'='*60}")
-    for k, v in sorted(search.best_params_.items()):
-        val = f"'{v}'" if isinstance(v, str) else v
-        print(f"  {k}={val},")
 
 
 if __name__ == "__main__":

--- a/README.md
+++ b/README.md
@@ -70,8 +70,9 @@ graph LR
     A[DEM<br/>Elevation] --> B[TauDEM<br/>Hydro Features]
     B --> C[Feature Eng<br/>23 Features]
     C --> D[Training Data<br/>OR/CA Wetlands]
-    D --> E[XGBoost<br/>200 trees]
-    E --> F[Prediction<br/>Probability Map]
+    D --> E[Hyperparameter<br/>Tuning]
+    E --> F[XGBoost<br/>Tuned Model]
+    F --> G[Prediction<br/>Probability Map]
 ```
 
 ### Pipeline Steps
@@ -86,8 +87,9 @@ graph LR
 | **4b. Soil** | Soil property rasters cropped to watershed | Depth to restrictive layer, hydraulic connectivity, organic matter |
 | **5. Stacking** | Combine all features | 23-band multi-layer raster |
 | **6. Training Data** | Sample wetland labels from OR/CA geodatabases | 100,000 labeled pixels (1:4 meadow:non-meadow ratio) |
-| **7. Model** | XGBoost classifier | Trained model `.pkl` |
-| **8. Prediction** | Apply model to watershed | Meadow probability map (0–1) |
+| **7. Hyperparameter Tuning** | Per-watershed randomized search (100 combinations, 5-fold CV) | `best_params.json` |
+| **8. Model** | XGBoost classifier with tuned hyperparameters | Trained model `.pkl` |
+| **9. Prediction** | Apply model to watershed | Meadow probability map (0–1) |
 
 ### Features Generated (23 Total)
 
@@ -145,7 +147,7 @@ Lost-Meadows/
     ├── predict_meadows.py       # Inference — applies model to feature stack
     ├── mlflow_config.py         # DagsHub experiment tracking config
     ├── train_random_forest.py   # Comparison model (not in pipeline — see note in file)
-    └── xgboost_gridsearch.py    # Hyperparameter tuning utility (not in pipeline — see note in file)
+    └── xgboost_gridsearch.py    # Per-watershed hyperparameter tuning (runs automatically in pipeline)
 ```
 
 ---
@@ -198,8 +200,11 @@ python stack_features.py Hunter_Creek_1710031205
 cd ../Wetlands
 python prepare_training_data.py Hunter_Creek_1710031205
 
-# Step 7-8: Train and predict
+# Step 7: Hyperparameter tuning (saves best_params.json)
 cd ../ModelTraining
+python xgboost_gridsearch.py Hunter_Creek_1710031205
+
+# Step 8-9: Train and predict (train_xgboost.py loads best_params.json automatically)
 python train_xgboost.py Hunter_Creek_1710031205
 python predict_meadows.py Hunter_Creek_1710031205
 ```
@@ -216,7 +221,7 @@ python predict_meadows.py Hunter_Creek_1710031205
 
 Based on Cummings et al. (2023) with an expanded 23-feature set:
 
-- **Algorithm**: XGBoost (200 trees)
+- **Algorithm**: XGBoost with per-watershed hyperparameter tuning
 - **Features**: 23 hydrogeomorphic and soil variables (expanded from original 9)
 - **Training ratio**: 1:4 (meadow : non-meadow pixels)
 - **Validation**: 75/25 train/test split

--- a/SETUP.md
+++ b/SETUP.md
@@ -295,7 +295,7 @@ Lost-Meadows/
     ├── predict_meadows.py
     ├── mlflow_config.py
     ├── train_random_forest.py         # Comparison only — not in pipeline
-    └── xgboost_gridsearch.py          # Tuning utility — not in pipeline
+    └── xgboost_gridsearch.py          # Per-watershed hyperparameter tuning (runs automatically in pipeline)
 ```
 
 ---

--- a/Tests/TestPipeline/run_test.py
+++ b/Tests/TestPipeline/run_test.py
@@ -346,19 +346,25 @@ def run_pipeline_steps():
                f"missing from Wetlands/: {', '.join(missing)} — "
                "download from WetlandGeodatabases release (see SETUP.md Step 3)")
 
+    # Hyperparameter tuning
+    run_step("7. Hyperparameter tuning",
+             f"python xgboost_gridsearch.py {TEST_WATERSHED}",
+             REPO_ROOT / "ModelTraining",
+             timeout=300)
+
     # Training — uses test_train.py to avoid DagsHub network calls
-    run_step("7. Train XGBoost",
+    run_step("8. Train XGBoost",
              f"python Tests/TestPipeline/test_train.py {TEST_WATERSHED}",
              REPO_ROOT)
 
     # Prediction (only if model file was produced)
     model_file = OUTPUT_DIR / "xgboost_model.pkl"
     if model_file.exists():
-        run_step("8. Predict meadow probabilities",
+        run_step("9. Predict meadow probabilities",
                  f"python predict_meadows.py {TEST_WATERSHED}",
                  REPO_ROOT / "ModelTraining")
     else:
-        record("8. Predict meadow probabilities", "SKIP",
+        record("9. Predict meadow probabilities", "SKIP",
                "model not produced — training step was skipped or failed")
 
 

--- a/Tests/TestPipeline/test_train.py
+++ b/Tests/TestPipeline/test_train.py
@@ -12,6 +12,7 @@ Usage (called automatically by run_test.py):
     python Tests/TestPipeline/test_train.py <watershed_name>
 """
 
+import json
 import sys
 import numpy as np
 import pandas as pd
@@ -48,10 +49,19 @@ def main(watershed_name):
     neg = np.sum(y_train == 0)
     scale_pos_weight = neg / pos if pos > 0 else 1.0
 
+    # Load tuned params from grid search if available
+    params_path = output_dir / "best_params.json"
+    if params_path.exists():
+        with open(params_path) as f:
+            tuned = json.load(f)
+        tuned.pop("scale_pos_weight", None)
+        tuned["n_estimators"] = 10  # Keep fast for test regardless of tuned value
+    else:
+        tuned = {"max_depth": 4, "learning_rate": 0.1}
+
     model = XGBClassifier(
-        n_estimators=10,          # Reduced from 200 — speed only, not accuracy
-        max_depth=4,
-        learning_rate=0.1,
+        n_estimators=10,          # Reduced from tuned value — speed only, not accuracy
+        **{k: v for k, v in tuned.items() if k != "n_estimators"},
         scale_pos_weight=scale_pos_weight,
         random_state=42,
         eval_metric="logloss",

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -17,8 +17,9 @@ Steps executed:
   4b. Soil features processing
   5. Feature stacking (23 features)
   6. Training data preparation
-  7. Model training
-  8. Meadow probability prediction
+  7. Per-watershed hyperparameter tuning (100 combinations, 5-fold CV)
+  8. Model training (uses tuned hyperparameters)
+  9. Meadow probability prediction
 """
 
 import subprocess
@@ -84,6 +85,7 @@ def main(input_dem):
     print(f"Watershed: {watershed_name}")
     print(f"Output directory: {base_dir}/GEE/TIF_Output/{watershed_name}")
     print(f"\nThis will execute 9 major steps and may take 2-4 hours.")
+    print(f"  (Includes per-watershed hyperparameter tuning — adds ~1 minute)")
     print(f"{'='*70}")
 
     input(f"\nPress Enter to start the pipeline...")
@@ -146,16 +148,23 @@ def main(input_dem):
         cwd=base_dir / "Wetlands"
     )
 
-    # Step 7: Train model
+    # Step 7: Hyperparameter tuning
     run_step(
-        "7. Train XGBoost Model (200 trees, 75/25 split)",
+        "7. Tune XGBoost Hyperparameters (100 combinations, 5-fold CV)",
+        f"python xgboost_gridsearch.py {watershed_name}",
+        cwd=base_dir / "ModelTraining"
+    )
+
+    # Step 8: Train model
+    run_step(
+        "8. Train XGBoost Model (tuned hyperparameters, 75/25 split)",
         f"python train_xgboost.py {watershed_name}",
         cwd=base_dir / "ModelTraining"
     )
 
-    # Step 8: Predict meadow probabilities
+    # Step 9: Predict meadow probabilities
     run_step(
-        "8. Generate Meadow Probability Map",
+        "9. Generate Meadow Probability Map",
         f"python predict_meadows.py {watershed_name}",
         cwd=base_dir / "ModelTraining"
     )


### PR DESCRIPTION
**Per-watershed hyperparameter tuning**                                      
  XGBoost was previously using hyperparameters tuned on Bear Creek for all
  watersheds, causing poor predictions on other watersheds (dominated by   
  1-2 features, watercolor-like artifacts). The grid search now runs
  automatically as Step 7 of the pipeline before training. It performs 100 
  randomized combinations with 5-fold cross-validation (~25 seconds on 16
  cores) and saves the best parameters to best_params.json in the watershed
   output directory. train_xgboost.py loads these automatically, falling
  back to Bear Creek defaults if not found.

  **Boundary pixel nodata encoding fix**
  calculate_advanced_features.py was only handling NaN-encoded nodata
  pixels when computing the watershed mask. Watersheds exported from GEE   
  can encode outside-boundary pixels as NaN, large positive values
  (~3.4e38), or large negative values depending on export settings. The fix
   normalizes all three encodings to NaN before computing terrain features,
   ensuring fill_boundary_nans correctly identifies the watershed boundary
  regardless of how the DEM was exported.

Closes #95 