### PR TITLE
Small Watersheds Accounted For

### DIFF
--- a/Wetlands/prepare_training_data.py
+++ b/Wetlands/prepare_training_data.py
@@ -225,9 +225,13 @@ def sample_training_points(wetland_raster, features_raster, n_wetland=1000, n_no
         print("ERROR: No valid wetland pixels found!")
         print("Wetlands may not overlap with valid feature data")
         return None, None
-    
-    # Sample
+
+    # Sample — maintain 1:4 ratio if wetland pixels are scarce
     n_wetland_sample = min(n_wetland, len(wetland_pixels))
+    if n_wetland_sample < n_wetland:
+        print(f"\n  WARNING: Only {n_wetland_sample:,} wetland pixels available (target: {n_wetland:,})")
+        print(f"  Scaling non-wetland to maintain 1:4 ratio ({n_wetland_sample * 4:,} non-wetland)")
+        n_non_wetland = n_wetland_sample * 4
     n_non_wetland_sample = min(n_non_wetland, len(non_wetland_pixels))
     
     print(f"\nSampling {n_wetland_sample:,} wetland points...")


### PR DESCRIPTION
If available wetland pixels are below the 20k target, scale non-wetland samples to wetland_count × 4 instead of the fixed 80k cap to maintain the intended 1:4 class ratio. Previously, small watersheds like Iron Gate (3,306 wetland pixels) were being trained with an unintended 1:24 ratio.

Closes #103 