### PR TITLE
Replace Old 800m Soil Features with POLARIS 30m

### DIFF
--- a/FeatureEngineering/Advanced/calculate_advanced_features.py
+++ b/FeatureEngineering/Advanced/calculate_advanced_features.py
@@ -246,7 +246,7 @@ def main(watershed_name):
 
     print(f"\n{'='*60}")
     print("Advanced features complete!")
-    print(f"Added 11 new features → Total: 20 features")
+    print(f"Added 11 new features → 20 terrain features total")
     print(f"{'='*60}")
 
     # Clean up TauDEM intermediate files (now that ALL features are done)

--- a/FeatureEngineering/Soil/calculate_soil_features.py
+++ b/FeatureEngineering/Soil/calculate_soil_features.py
@@ -5,15 +5,15 @@ Process soil features for meadow detection.
 Crops and resamples soil TIF files to match individual watershed
 resolution (10m) and extent.
 
-Expected input files in GEE/TIF_Input/Soil/:
-  - depth_to_restrictive_layer.tif   (depth in cm)
-  - hydraulic_connectivity.tif        (Ksat or similar, mm/hr)
-  - organic_matter_pct.tif            (percent by weight)
+Expected input files in GEE/TIF_Input/Soil/Soils/ (POLARIS 30m, 0-5cm depth):
+  - polaris_clay_pct_0_5cm.tif
+  - polaris_organic_matter_0_5cm.tif
+  - polaris_saturated_water_content_0_5cm.tif
 
 Output files written to GEE/TIF_Output/<watershed_name>/:
-  - soil_depth_restrictive.tif
-  - soil_hydraulic_connectivity.tif
+  - soil_clay_pct.tif
   - soil_organic_matter.tif
+  - soil_saturated_water_content.tif
 
 NOTE: This script is standalone for now. It will be integrated into
       run_pipeline.py once soil TIF inputs are finalized.
@@ -85,23 +85,24 @@ def process_soil_features(watershed_name):
 
     # Define soil layers to process
     # Format: (input_filename, output_name, description, resampling_method)
+    # POLARIS 30m soil properties (0-5cm depth) — 3 selected features
     soil_layers = [
         (
-            "soil_depth_restrictive.tif",
-            "soil_depth_restrictive",
-            "Depth to restrictive layer (cm)",
+            "Soils/polaris_clay_pct_0_5cm.tif",
+            "soil_clay_pct",
+            "Clay percentage (%)",
             Resampling.bilinear,
         ),
         (
-            "soil_hydraulic_connectivity.tif",
-            "soil_hydraulic_connectivity",
-            "Soil hydraulic connectivity (mm/hr)",
-            Resampling.bilinear,
-        ),
-        (
-            "soil_organic_matter.tif",
+            "Soils/polaris_organic_matter_0_5cm.tif",
             "soil_organic_matter",
-            "Soil organic matter (% by weight)",
+            "Organic matter log10(%)",
+            Resampling.bilinear,
+        ),
+        (
+            "Soils/polaris_saturated_water_content_0_5cm.tif",
+            "soil_saturated_water_content",
+            "Saturated volumetric water content (m³/m³)",
             Resampling.bilinear,
         ),
     ]

--- a/FeatureStacking/stack_features.py
+++ b/FeatureStacking/stack_features.py
@@ -52,10 +52,10 @@ def stack_features(watershed_name):
         f"{output_dir}/elev_std_9x9.tif",                   # 19. Elevation std dev 9x9
         f"{output_dir}/slope_std_9x9.tif",                  # 20. Slope std dev 9x9
 
-        # Soil features (3)
-        f"{output_dir}/soil_depth_restrictive.tif",          # 21. Depth to restrictive layer
-        f"{output_dir}/soil_hydraulic_connectivity.tif",     # 22. Soil hydraulic connectivity
-        f"{output_dir}/soil_organic_matter.tif",             # 23. Soil organic matter
+        # Soil features (3) — POLARIS 30m, 0-5cm depth
+        f"{output_dir}/soil_clay_pct.tif",                   # 21. Clay percentage
+        f"{output_dir}/soil_organic_matter.tif",             # 22. Organic matter
+        f"{output_dir}/soil_saturated_water_content.tif",    # 23. Saturated water content
 
     ]
 
@@ -84,10 +84,10 @@ def stack_features(watershed_name):
         "elev_std_9x9",
         "slope_std_9x9",
 
-        # Soil features (3)
-        "soil_depth_restrictive",
-        "soil_hydraulic_connectivity",
+        # Soil features (3) — POLARIS 30m
+        "soil_clay_pct",
         "soil_organic_matter",
+        "soil_saturated_water_content",
 
     ]
     

--- a/ModelTraining/train_xgboost.py
+++ b/ModelTraining/train_xgboost.py
@@ -31,8 +31,8 @@ FEATURE_NAMES = [
     'aspect', 'curvature_profile', 'curvature_plan', 'elevation',
     'tpi_3x3', 'tpi_11x11', 'tpi_21x21', 'tri',
     'elev_std_3x3', 'elev_std_9x9', 'slope_std_9x9',
-    # Soil features (3)
-    'soil_depth_restrictive', 'soil_hydraulic_connectivity', 'soil_organic_matter'
+    # Soil features (3) — POLARIS 30m
+    'soil_clay_pct', 'soil_organic_matter', 'soil_saturated_water_content',
 ]
 
 def get_repo_root():

--- a/ModelTraining/xgboost_gridsearch.py
+++ b/ModelTraining/xgboost_gridsearch.py
@@ -32,8 +32,8 @@ FEATURE_NAMES = [
     'aspect', 'curvature_profile', 'curvature_plan', 'elevation',
     'tpi_3x3', 'tpi_11x11', 'tpi_21x21', 'tri',
     'elev_std_3x3', 'elev_std_9x9', 'slope_std_9x9',
-    # Soil features (3)
-    'soil_depth_restrictive', 'soil_hydraulic_connectivity', 'soil_organic_matter',
+    # Soil features (3) — POLARIS 30m
+    'soil_clay_pct', 'soil_organic_matter', 'soil_saturated_water_content',
 ]
 
 def main(watershed_name):

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ All required data files are provided as GitHub Releases. Go to the [Releases pag
 
 | Release | Contents | Destination |
 |---------|----------|-------------|
-| **TIFInputFiles** | 3 soil TIF files | Extract into `GEE/TIF_Input/Soil/` |
+| **TIFInputFiles** | 3 POLARIS 30m soil TIF files | Extract into `GEE/TIF_Input/Soil/Soils/` |
 | **WetlandGeodatabases** | OR + CA wetland geodatabases (zipped) | Unzip each `.gdb` folder into `Wetlands/` |
 | **GEEInputFiles** | 122 watershed rasters split across two zip files | Unzip both archives, find the desired watershed `.tif`, and place it into `GEE/TIF_Input/` |
 
@@ -84,7 +84,7 @@ graph LR
 | **2b. TWI 100m** | TWI at landscape scale, resampled to 10m | `twi_100m.tif` |
 | **3. Terrain** | Slope and elevation variability | Slope, relative elevation, std deviations |
 | **4. Advanced** | Aspect, curvature, TPI, TRI | 11 additional terrain features |
-| **4b. Soil** | Soil property rasters cropped to watershed | Depth to restrictive layer, hydraulic connectivity, organic matter |
+| **4b. Soil** | POLARIS 30m soil property rasters cropped to watershed | Clay %, organic matter, saturated water content |
 | **5. Stacking** | Combine all features | 23-band multi-layer raster |
 | **6. Training Data** | Sample wetland labels from OR/CA geodatabases | 100,000 labeled pixels (1:4 meadow:non-meadow ratio) |
 | **7. Hyperparameter Tuning** | Per-watershed randomized search (100 combinations, 5-fold CV) | `best_params.json` |
@@ -99,7 +99,7 @@ graph LR
 | **Terrain** | Slope, relative elevation, elevation std dev, slope std dev | 4 |
 | **Stream Distance** | Surface distance (dd_s), horizontal distance (dd_h), vertical distance (dd_v) | 3 |
 | **Advanced Terrain** | Aspect, profile curvature, plan curvature, absolute elevation, TPI 3×3, TPI 11×11, TPI 21×21, TRI, elevation std 3×3, elevation std 9×9, slope std 9×9 | 11 |
-| **Soil** | Depth to restrictive layer, hydraulic connectivity, organic matter % | 3 |
+| **Soil** | Clay % (POLARIS 30m), organic matter (POLARIS 30m), saturated water content (POLARIS 30m) | 3 |
 
 > Precipitation features were evaluated and excluded — they did not improve model performance on this dataset.
 
@@ -120,6 +120,7 @@ Lost-Meadows/
 │   ├── MeadowVisualization.js      # Visualization helpers
 │   ├── TIF_Input/                  # Place watershed DEM files here
 │   │   └── Soil/                   # Soil TIF files (from TIFInputFiles release)
+│   │       └── Soils/              # POLARIS 30m soil TIFs
 │   └── TIF_Output/                 # Pipeline outputs organized by watershed
 │       ├── Hunter_Creek_1710031205/
 │       ├── Bear_Creek_1710030801/

--- a/SETUP.md
+++ b/SETUP.md
@@ -88,16 +88,17 @@ There are three releases to download. Follow the instructions for each below.
 
 ### Release 1: TIFInputFiles (Soil Data)
 
-This release contains the three soil TIF files required by the pipeline.
+This release contains the three POLARIS 30m soil TIF files required by the pipeline.
 
 1. Download the **TIFInputFiles** release asset.
-2. Extract the files into `GEE/TIF_Input/Soil/`:
+2. Extract the files into `GEE/TIF_Input/Soil/Soils/`:
 
 ```
 GEE/TIF_Input/Soil/
-├── depth_to_restrictive_layer.tif
-├── hydraulic_connectivity.tif
-└── organic_matter_pct.tif
+└── Soils/
+    ├── polaris_clay_pct_0_5cm.tif
+    ├── polaris_organic_matter_0_5cm.tif
+    └── polaris_saturated_water_content_0_5cm.tif
 ```
 
 These files are already in `.gitignore` — they will not be committed.
@@ -137,9 +138,10 @@ GEE/TIF_Input/
 ├── Hunter_Creek_1710031205.tif      ← example watershed
 ├── Bear_Creek_1710030801.tif        ← another watershed
 └── Soil/
-    ├── depth_to_restrictive_layer.tif
-    ├── hydraulic_connectivity.tif
-    └── organic_matter_pct.tif
+    └── Soils/
+        ├── polaris_clay_pct_0_5cm.tif
+        ├── polaris_organic_matter_0_5cm.tif
+        └── polaris_saturated_water_content_0_5cm.tif
 ```
 
 You only need to place the watersheds you intend to process — you do not need all 122 at once. All `.tif` files in `GEE/TIF_Input/` are already in `.gitignore`.
@@ -207,9 +209,9 @@ else
 fi
 
 # Check for soil data
-if [ -f "GEE/TIF_Input/Soil/depth_to_restrictive_layer.tif" ] && \
-   [ -f "GEE/TIF_Input/Soil/hydraulic_connectivity.tif" ] && \
-   [ -f "GEE/TIF_Input/Soil/organic_matter_pct.tif" ]; then
+if [ -f "GEE/TIF_Input/Soil/Soils/polaris_clay_pct_0_5cm.tif" ] && \
+   [ -f "GEE/TIF_Input/Soil/Soils/polaris_organic_matter_0_5cm.tif" ] && \
+   [ -f "GEE/TIF_Input/Soil/Soils/polaris_saturated_water_content_0_5cm.tif" ]; then
     echo "Soil TIF files found!"
 else
     echo "WARNING: Soil TIF files missing — download from TIFInputFiles release"
@@ -267,9 +269,10 @@ Lost-Meadows/
 │   ├── TIF_Input/               # Watershed DEMs go here
 │   │   ├── Hunter_Creek_1710031205.tif
 │   │   └── Soil/                # Soil TIFs go here
-│   │       ├── depth_to_restrictive_layer.tif
-│   │       ├── hydraulic_connectivity.tif
-│   │       └── organic_matter_pct.tif
+│   │       └── Soils/
+│   │           ├── polaris_clay_pct_0_5cm.tif
+│   │           ├── polaris_organic_matter_0_5cm.tif
+│   │           └── polaris_saturated_water_content_0_5cm.tif
 │   └── TIF_Output/              # Created automatically during pipeline run
 │       └── Hunter_Creek_1710031205/
 │

--- a/Tests/TestPipeline/run_test.py
+++ b/Tests/TestPipeline/run_test.py
@@ -55,11 +55,11 @@ TEST_WATERSHED = "test_watershed"
 OUTPUT_DIR = REPO_ROOT / "GEE" / "TIF_Output" / TEST_WATERSHED
 SOIL_DIR = REPO_ROOT / "GEE" / "TIF_Input" / "Soil"
 
-# Soil file names the pipeline expects
+# Soil file names the pipeline expects (POLARIS 30m, stored in Soil/Soils/)
 SOIL_FILES = {
-    "soil_depth_restrictive.tif": (10.0, 200.0),
-    "soil_hydraulic_connectivity.tif": (0.1, 100.0),
-    "soil_organic_matter.tif": (0.5, 10.0),
+    "Soils/polaris_clay_pct_0_5cm.tif":               (5.0, 60.0),
+    "Soils/polaris_organic_matter_0_5cm.tif":         (-2.0, 2.0),
+    "Soils/polaris_saturated_water_content_0_5cm.tif":(0.3, 0.8),
 }
 
 FEATURE_NAMES = [
@@ -68,7 +68,8 @@ FEATURE_NAMES = [
     "aspect", "curvature_profile", "curvature_plan", "elevation",
     "tpi_3x3", "tpi_11x11", "tpi_21x21", "tri",
     "elev_std_3x3", "elev_std_9x9", "slope_std_9x9",
-    "soil_depth_restrictive", "soil_hydraulic_connectivity", "soil_organic_matter",
+    # Soil features (3) — POLARIS 30m
+    "soil_clay_pct", "soil_organic_matter", "soil_saturated_water_content",
 ]
 
 # Tracks soil TIFs we created so we can clean them up
@@ -208,6 +209,7 @@ def make_synthetic_soil_tifs():
     rng = np.random.default_rng(99)
     for filename, (lo, hi) in SOIL_FILES.items():
         dest = SOIL_DIR / filename
+        dest.parent.mkdir(parents=True, exist_ok=True)
         if dest.exists():
             continue  # Real file present — don't overwrite it
         data = rng.uniform(lo, hi, (20, 20)).astype(np.float32)

--- a/Tests/TestPipeline/test_train.py
+++ b/Tests/TestPipeline/test_train.py
@@ -28,7 +28,8 @@ FEATURE_NAMES = [
     "aspect", "curvature_profile", "curvature_plan", "elevation",
     "tpi_3x3", "tpi_11x11", "tpi_21x21", "tri",
     "elev_std_3x3", "elev_std_9x9", "slope_std_9x9",
-    "soil_depth_restrictive", "soil_hydraulic_connectivity", "soil_organic_matter",
+    # Soil features (3) — POLARIS 30m
+    "soil_clay_pct", "soil_organic_matter", "soil_saturated_water_content",
 ]
 
 def main(watershed_name):

--- a/Wetlands/prepare_training_data.py
+++ b/Wetlands/prepare_training_data.py
@@ -325,8 +325,8 @@ def main(watershed_name):
         'aspect', 'curvature_profile', 'curvature_plan', 'elevation',
         'tpi_3x3', 'tpi_11x11', 'tpi_21x21', 'tri',
         'elev_std_3x3', 'elev_std_9x9', 'slope_std_9x9',
-        # Soil features (3)
-        'soil_depth_restrictive', 'soil_hydraulic_connectivity', 'soil_organic_matter'
+        # Soil features (3) — POLARIS 30m
+        'soil_clay_pct', 'soil_organic_matter', 'soil_saturated_water_content',
     ]
     
     df = pd.DataFrame(features, columns=feature_names)

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -184,7 +184,7 @@ def main(input_dem):
     print(f"\nKey files generated:")
     print(f"  ✓ 23 feature rasters (terrain + soil)")
     print(f"     - dd_h, dd_s, dd_v, slope, TWI, aspect, curvature, TPI, TRI, etc.")
-    print(f"     - soil_depth_restrictive, soil_hydraulic_connectivity, soil_organic_matter")
+    print(f"     - soil_clay_pct, soil_organic_matter, soil_saturated_water_content (POLARIS 30m)")
     print(f"  ✓ features_stacked.tif (23-band multi-band raster)")
     print(f"  ✓ training_data_real.csv")
     print(f"  ✓ xgboost_model.pkl (trained model)")


### PR DESCRIPTION
Swaps out the 3 old 800m soil features (depth to restrictive layer,     
  hydraulic connectivity, organic matter) for 3 POLARIS 30m features: clay
   %, organic matter, and saturated water content.                        
                                                            
  Changes:
  - Updated all pipeline scripts (calculate_soil_features.py,
  stack_features.py, train_xgboost.py, xgboost_gridsearch.py,             
  prepare_training_data.py, run_pipeline.py) to use new feature names
  - Updated test pipeline (run_test.py, test_train.py) to match           
  - Deleted old 800m TIF files; kept only the 3 used POLARIS files in
  Soil/Soils/                                                             
  - Updated README.md and SETUP.md to reflect new file paths and feature  
  descriptions                                                            
                                                                          
  Why POLARIS: 30m resolution is more appropriate than 800m for a 10m
  raster. Clay %, organic matter, and saturated water content are directly
   physically meaningful for meadow detection (water retention, wet soil
  accumulation).

Closes #108 