### PR TITLE
Added PFO Training Label Data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,11 +13,12 @@ GEE/TIF_Output/**/*.tif
 Wetlands/*.gdb/
 Wetlands/CA_geodatabase_wetlands.gdb/
 Wetlands/OR_geodatabase_wetlands.gdb/
-Wetlands/wetlands_PEM_PSS_bioregion.geojson
-Wetlands/wetlands_PEM_PSS_bioregion.shp
-Wetlands/wetlands_PEM_PSS_bioregion.dbf
-Wetlands/wetlands_PEM_PSS_bioregion.shx
-Wetlands/wetlands_PEM_PSS_bioregion.prj
+Wetlands/*.geojson/
+Wetlands/wetlands_PEM_PSS_PFO_bioregion.dbf
+Wetlands/wetlands_PEM_PSS_PFO_bioregion.geojson
+Wetlands/wetlands_PEM_PSS_PFO_bioregion.shp
+Wetlands/wetlands_PEM_PSS_PFO_bioregion.prj
+Wetlands/wetlands_PEM_PSS_PFO_bioregion.shx
 
 # Output directories with generated data
 GEE/TIF_Output/*/

--- a/GEE/LostMeadowsApplication.js
+++ b/GEE/LostMeadowsApplication.js
@@ -200,6 +200,8 @@ var wetlandsPEM = ee.FeatureCollection(WETLANDS)
   .filter(ee.Filter.stringStartsWith('ATTRIBUTE', 'PEM'));
 var wetlandsPSS = ee.FeatureCollection(WETLANDS)
   .filter(ee.Filter.stringStartsWith('ATTRIBUTE', 'PSS'));
+var wetlandsPFO = ee.FeatureCollection(WETLANDS)
+  .filter(ee.Filter.stringStartsWith('ATTRIBUTE', 'PFO'));
 
 
 // ============================================================
@@ -370,6 +372,7 @@ var droughtLayer = null;
 var nlcdLayer    = null;
 var wetlandsLayer = null;
 var wetlandsPSSLayer = null;
+var wetlandsPFOLayer = null;
 
 /** Removes and re-adds the SNODAS snowpack layer with current clip/vis. */
 function refreshSnow() {
@@ -404,21 +407,28 @@ function refreshNlcd() {
 }
 
 /** Removes and re-adds the NWI wetlands overlay, clipped to current watershed. */
+
 function refreshWetlands() {
   var clip = getClipTarget();
-  if (wetlandsLayer) map.remove(wetlandsLayer);
+  if (wetlandsLayer)    map.remove(wetlandsLayer);
   if (wetlandsPSSLayer) map.remove(wetlandsPSSLayer);
+  if (wetlandsPFOLayer) map.remove(wetlandsPFOLayer);
 
   wetlandsLayer = ui.Map.Layer(
-    wetlandsPEM.filterBounds(clip), { color: '1a9641' },
+    wetlandsPEM.filterBounds(clip), { color: '4c956c' },
     'NWI Wetlands — PEM', true, 0.8
   );
   wetlandsPSSLayer = ui.Map.Layer(
-    wetlandsPSS.filterBounds(clip), { color: 'a8d5b5' },
+    wetlandsPSS.filterBounds(clip), { color: 'e9c46a' },
     'NWI Wetlands — PSS', true, 0.8
+  );
+  wetlandsPFOLayer = ui.Map.Layer(
+    wetlandsPFO.filterBounds(clip), { color: 'e76f51' },
+    'NWI Wetlands — PFO', true, 0.8
   );
   map.add(wetlandsLayer);
   map.add(wetlandsPSSLayer);
+  map.add(wetlandsPFOLayer);
 }
 
 /**
@@ -535,8 +545,9 @@ function updateWetlandsInspectorLegend(visible) {
   if (!visible) return;
 
   [
-    { color: '1a9641', label: 'PEM — Active wet meadow' },
-    { color: 'a8d5b5', label: 'PSS — Shrub-encroached meadow' }
+    { color: '4c956c', label: 'PEM — Active wet meadow' },
+    { color: 'e9c46a', label: 'PSS — Shrub-encroached meadow' },
+    { color: 'e76f51', label: 'PFO — Conifer-encroached meadow' }
   ].forEach(function(c) {
     wetlandsInspectorLegendPanel.add(ui.Panel([
       ui.Label('', {
@@ -701,7 +712,7 @@ var nlcdCheck = ui.Checkbox({
 sidebar.add(nlcdCheck);
 
 var wetlandsCheck = ui.Checkbox({
-  label: 'NWI Wetlands (PEM/PSS)', value: false,
+  label: 'NWI Wetlands (PEM/PSS/PFO)', value: false,
   style: { fontSize: '12px', color: '#333333', margin: '2px 0 8px 0' }
 });
 sidebar.add(wetlandsCheck);
@@ -1048,6 +1059,7 @@ wetlandsCheck.onChange(function(val) {
   } else {
     if (wetlandsLayer)    { map.remove(wetlandsLayer);    wetlandsLayer    = null; }
     if (wetlandsPSSLayer) { map.remove(wetlandsPSSLayer); wetlandsPSSLayer = null; }
+    if (wetlandsPFOLayer) { map.remove(wetlandsPFOLayer); wetlandsPFOLayer = null; }
   }
   updateWetlandsInspectorLegend(val);
 });

--- a/Wetlands/export_wetlands.py
+++ b/Wetlands/export_wetlands.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-One-time export: filter OR + CA wetland .gdb files to PEM/PSS types,
+One-time export: filter OR + CA wetland .gdb files to PEM/PSS/PFO types,
 clip to the Cascade-Siskiyou bioregion, and save as GeoJSON for
 upload to GEE as a Table asset.
 
@@ -19,7 +19,7 @@ from shapely.geometry import box
 BIOREGION_BOUNDS = (-124.6, 41.0, -120.5, 44.5)  # (min_lon, min_lat, max_lon, max_lat)
 
 WETLANDS_DIR = Path(__file__).resolve().parent
-OUTPUT_PATH  = WETLANDS_DIR / 'wetlands_PEM_PSS_bioregion.geojson'
+OUTPUT_PATH  = WETLANDS_DIR / 'wetlands_PEM_PSS_PFO_bioregion.geojson'
 
 def load_and_filter(gdb_path, layer_name, clip_geom, label):
     print(f'\nLoading {label}...')
@@ -27,9 +27,9 @@ def load_and_filter(gdb_path, layer_name, clip_geom, label):
     print(f'  Raw polygons in bounding box: {len(gdf):,}')
 
     # Filter to meadow-relevant Cowardin types
-    mask = gdf['ATTRIBUTE'].str.startswith(('PEM', 'PSS'), na=False)
+    mask = gdf['ATTRIBUTE'].str.startswith(('PEM', 'PSS', 'PFO'), na=False)
     gdf  = gdf[mask].copy()
-    print(f'  PEM/PSS polygons: {len(gdf):,}')
+    print(f'  PEM/PSS/PFO polygons: {len(gdf):,}')
 
     # Keep only columns needed for the overlay
     keep = ['ATTRIBUTE', 'WETLAND_TYPE', 'ACRES', 'geometry']
@@ -70,12 +70,12 @@ def main():
         crs=parts[0].crs
     ).to_crs('EPSG:4326')
 
-    print(f'\nTotal PEM/PSS polygons for export: {len(merged):,}')
+    print(f'\nTotal PEM/PSS/PFO polygons for export: {len(merged):,}')
     merged.to_file(OUTPUT_PATH, driver='GeoJSON')
     print(f'Saved: {OUTPUT_PATH}')
     print('\nNext: upload to GEE')
     print('  earthengine upload table \\')
-    print('    --asset_id projects/lost-meadows/assets/wetlands_PEM_PSS \\')
+    print('    --asset_id projects/lost-meadows/assets/wetlands_PEM_PSS_PFO \\')
     print(f'   {OUTPUT_PATH}')
 
 if __name__ == '__main__':


### PR DESCRIPTION
  Added PFO (Palustrine Forested — conifer-encroached meadow) alongside PEM and PSS after initial implementation. All three types are now displayed as distinct color-coded layers. The export script, GEE asset, and app legend have all been updated to reflect this.
 Derived shapefiles excluded from the repo via .gitignore regenerate with `Wetlands/export_wetlands_for_gee.py`.

Closes #117 