### PR TITLE
Add step zero to pre-process raster

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -10,6 +10,7 @@ Example:
   python run_pipeline.py GEE/TIF_Input/Bear_Creek_Watershed_10m.tif
 
 Steps executed:
+  0. Fix no data in raster
   1. TauDEM hydrological processing
   2. TWI calculation (10m and 100m scales)
   3. Terrain features calculation
@@ -27,6 +28,8 @@ import sys
 import os
 from pathlib import Path
 import time
+import numpy as np
+import rasterio
 
 def run_step(description, command, cwd=None):
     """Run a pipeline step and handle errors"""
@@ -59,6 +62,47 @@ def run_step(description, command, cwd=None):
 
     return result
 
+def fix_nodata(input_path: str, nodata_value: float = -9999.0) -> str:
+    """
+    Re-write a raster with an explicit NoData value before TauDEM processing.
+
+    Without a defined NoData value, TauDEM treats the empty border region as
+    real elevation data (~3e34), causing water to flow uphill out of the raster
+    and producing stripe artifacts in all downstream outputs.
+
+    Writes a new file at <stem>_fixed.tif and returns its path.
+    The original file is not modified.
+    """
+    input_path = str(input_path)
+    p = Path(input_path)
+    output_path = str(p.parent / (p.stem + "_fixed.tif"))
+
+    print(f"  Fixing NoData: {p.name} → {Path(output_path).name}")
+
+    with rasterio.open(input_path) as src:
+        profile = src.profile.copy()
+        data = src.read(1).astype(np.float32)
+        existing_nodata = src.nodata
+
+    # Mask: old NoData sentinel, NaN, Inf, and extreme border values (~3e34)
+    mask = np.zeros(data.shape, dtype=bool)
+    if existing_nodata is not None:
+        mask |= (data == existing_nodata)
+    mask |= np.isnan(data) | np.isinf(data) | (data > 1e10) | (data < -1e10)
+
+    n_masked = int(mask.sum())
+    print(f"  {n_masked:,} border/sentinel pixels masked as NoData ({nodata_value})")
+
+    data[mask] = nodata_value
+    profile.update(dtype=rasterio.float32, nodata=nodata_value)
+
+    with rasterio.open(output_path, "w", **profile) as dst:
+        dst.write(data, 1)
+
+    print(f"  ✓ Fixed raster written: {output_path}")
+    return output_path
+
+
 def get_repo_root():
     # run_pipeline.py is at the repo root
     return Path(__file__).resolve().parent
@@ -71,9 +115,6 @@ def main(input_dem):
         print(f"ERROR: Input DEM not found: {input_dem}")
         sys.exit(1)
 
-    # Extract watershed name from filename
-    watershed_name = Path(input_dem).stem
-
     # Get absolute paths
     base_dir = get_repo_root()
     input_dem_abs = Path(input_dem).absolute()
@@ -82,20 +123,33 @@ def main(input_dem):
     print(f"LOST MEADOWS DETECTION PIPELINE")
     print(f"{'='*70}")
     print(f"Input DEM: {input_dem}")
-    print(f"Watershed: {watershed_name}")
-    print(f"Output directory: {base_dir}/GEE/TIF_Output/{watershed_name}")
-    print(f"\nThis will execute 9 major steps and may take 2-4 hours.")
-    print(f"  (Includes per-watershed hyperparameter tuning — adds ~1 minute)")
+    print(f"\nThis will execute 10 major steps and may take 2-4 hours.")
+    print(f"  (Includes NoData fix, per-watershed hyperparameter tuning — adds ~1 minute)")
     print(f"{'='*70}")
 
     input(f"\nPress Enter to start the pipeline...")
 
     pipeline_start = time.time()
 
+    # Step 0: Fix NoData — must run before TauDEM
+    # Without an explicit NoData value, TauDEM treats the raster border as real
+    # elevation data, causing stripe artifacts throughout all downstream outputs.
+    print(f"\n{'='*70}")
+    print(f"STEP: 0. Fix NoData Value in Input DEM")
+    print(f"{'='*70}")
+    fixed_dem = fix_nodata(input_dem_abs)
+    fixed_dem_abs = Path(fixed_dem).absolute()
+
+    # Watershed name is derived from the FIXED DEM stem so all downstream steps
+    # look in the same output folder that TauDEM writes to.
+    watershed_name = fixed_dem_abs.stem
+    print(f"Watershed: {watershed_name}")
+    print(f"Output directory: {base_dir}/GEE/TIF_Output/{watershed_name}")
+
     # Step 1: TauDEM workflow
     run_step(
         "1. TauDEM Hydrological Processing",
-        f"python run_taudem_workflow.py {input_dem_abs}",
+        f"python run_taudem_workflow.py {fixed_dem_abs}",
         cwd=base_dir / "TauDEM"
     )
 
@@ -182,10 +236,10 @@ def main(input_dem):
     print(f"Total time: {total_minutes}m {total_seconds}s")
     print(f"\nOutputs in: {output_dir}")
     print(f"\nKey files generated:")
-    print(f"  ✓ 29 feature rasters (terrain + soil)")
+    print(f"  ✓ 23 feature rasters (terrain + soil)")
     print(f"     - dd_h, dd_s, dd_v, slope, TWI, aspect, curvature, TPI, TRI, etc.")
-    print(f"     - soil_clay_pct, soil_ksat, soil_organic_matter (POLARIS 30m, 3 depths each = 9 features)")
-    print(f"  ✓ features_stacked.tif (29-band multi-band raster)")
+    print(f"     - soil_depth_restrictive, soil_hydraulic_connectivity, soil_organic_matter")
+    print(f"  ✓ features_stacked.tif (23-band multi-band raster)")
     print(f"  ✓ training_data_real.csv")
     print(f"  ✓ xgboost_model.pkl (trained model)")
     print(f"  ✓ {watershed_name}_xgboost_model_probability.tif (FINAL OUTPUT)")


### PR DESCRIPTION
## Fix TauDEM stripe artifacts via explicit NoData pre-processing

### Problem
Input DEMs exported from GEE had no defined NoData value. TauDEM was interpreting the empty border region as real elevation data (~3e34), causing water to appear to flow uphill out of the raster. This produced stripe artifacts across all downstream outputs — TWI, distance-to-stream, and the final meadow probability raster.

Root cause confirmed by Adam Cummings (Cummings et al. 2023), who reproduced the bug independently using our exported raster.

### Fix
Added a Step 0 to `run_pipeline.py` that rewrites the input DEM with an explicit NoData flag of -9999 before TauDEM runs. Any border pixels at extreme sentinel values (>1e10 or <-1e10), NaN, or Inf are masked. The original file is not modified — a new `*_fixed.tif` is written and passed forward through the rest of the pipeline.

### Changes
- `run_pipeline.py` — added `fix_nodata()` function and Step 0; `watershed_name` now derived from the fixed DEM stem so all downstream steps resolve to the correct output directory

### Result
Stripe artifacts eliminated. Stream network now correctly follows drainage rather than exiting the raster boundary. 

Closes #109 