### PR TITLE
Pipeline output folder, SLURM job, and cluster reliability fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,11 @@ Desktop.ini
 
 # Logs
 *.log
+SLURM/logs/*.out
+SLURM/logs/*.err
+
+# Claude Code local settings
+.claude/
 
 # Compressed files
 *.zip

--- a/ModelTraining/mlflow_config.py
+++ b/ModelTraining/mlflow_config.py
@@ -28,16 +28,22 @@ DAGSHUB_REPO_NAME  = "Lost-Meadows"
 def init_mlflow(experiment_name: str) -> None:
     """Initialise DagsHub remote tracking and set the experiment.
 
-    Reads the DagsHub token from the DAGSHUB_USER_TOKEN environment variable.
+    Falls back to local MLflow tracking if DagsHub is unavailable (e.g.
+    rate-limited during large parallel runs on a cluster).
     """
     token = os.environ.get("DAGSHUB_USER_TOKEN")
     if token:
         os.environ["MLFLOW_TRACKING_USERNAME"] = DAGSHUB_REPO_OWNER
         os.environ["MLFLOW_TRACKING_PASSWORD"] = token
 
-    dagshub.init(
-        repo_owner=DAGSHUB_REPO_OWNER,
-        repo_name=DAGSHUB_REPO_NAME,
-        mlflow=True,
-    )
-    mlflow.set_experiment(experiment_name)
+    try:
+        dagshub.init(
+            repo_owner=DAGSHUB_REPO_OWNER,
+            repo_name=DAGSHUB_REPO_NAME,
+            mlflow=True,
+        )
+        mlflow.set_experiment(experiment_name)
+    except Exception as e:
+        print(f"WARNING: DagsHub unavailable ({e}), falling back to local MLflow tracking.")
+        mlflow.set_tracking_uri("mlruns")
+        mlflow.set_experiment(experiment_name)

--- a/ModelTraining/mlflow_config.py
+++ b/ModelTraining/mlflow_config.py
@@ -26,11 +26,18 @@ DAGSHUB_REPO_NAME  = "Lost-Meadows"
 
 
 def init_mlflow(experiment_name: str) -> None:
-    """Initialise DagsHub remote tracking and set the experiment.
+    """Initialise MLflow tracking.
 
-    Falls back to local MLflow tracking if DagsHub is unavailable (e.g.
-    rate-limited during large parallel runs on a cluster).
+    Uses local tracking when running inside a SLURM job to avoid rate-limiting
+    DagsHub with hundreds of concurrent API calls. Uses DagsHub remote tracking
+    for local/interactive runs.
     """
+    if os.environ.get("SLURM_JOB_ID"):
+        print("SLURM environment detected — using local MLflow tracking.")
+        mlflow.set_tracking_uri("mlruns")
+        mlflow.set_experiment(experiment_name)
+        return
+
     token = os.environ.get("DAGSHUB_USER_TOKEN")
     if token:
         os.environ["MLFLOW_TRACKING_USERNAME"] = DAGSHUB_REPO_OWNER

--- a/ModelTraining/train_xgboost.py
+++ b/ModelTraining/train_xgboost.py
@@ -66,7 +66,7 @@ def load_training_data(watershed_name):
     return features, labels
 
 
-def train_model(features, labels, watershed_name):
+def train_model(features, labels, watershed_name, ncores=1):
     """Train XGBoost classifier and log everything to MLflow / DagsHub."""
 
     print(f"\n{'='*60}")
@@ -149,7 +149,7 @@ def train_model(features, labels, watershed_name):
 
         xgb = XGBClassifier(
             **xgb_params,
-            n_jobs=-1,
+            n_jobs=ncores,
             eval_metric='logloss',
             verbosity=0,
         )
@@ -227,10 +227,10 @@ def train_model(features, labels, watershed_name):
     return xgb
 
 
-def main(watershed_name):
+def main(watershed_name, ncores=1):
     init_mlflow(MLFLOW_EXPERIMENT)
     features, labels = load_training_data(watershed_name)
-    train_model(features, labels, watershed_name)
+    train_model(features, labels, watershed_name, ncores)
 
     print(f"\n{'='*60}")
     print("Training Complete!")
@@ -255,4 +255,5 @@ if __name__ == "__main__":
     else:
         watershed_name = sys.argv[1]
 
-    main(watershed_name)
+    ncores = int(sys.argv[2]) if len(sys.argv) > 2 else 1
+    main(watershed_name, ncores)

--- a/ModelTraining/xgboost_gridsearch.py
+++ b/ModelTraining/xgboost_gridsearch.py
@@ -38,7 +38,7 @@ FEATURE_NAMES = [
     'soil_organic_matter_0_5cm', 'soil_organic_matter_5_15cm', 'soil_organic_matter_15_30cm',
 ]
 
-def main(watershed_name):
+def main(watershed_name, ncores=1):
 
     # Load training data
     csv = get_repo_root() / "GEE" / "TIF_Output" / watershed_name / "training_data_real.csv"
@@ -76,7 +76,7 @@ def main(watershed_name):
 
     base_model = XGBClassifier(
         random_state=42,
-        n_jobs=-1,
+        n_jobs=1,
         eval_metric='logloss',
         verbosity=0
     )
@@ -98,7 +98,7 @@ def main(watershed_name):
         scoring='roc_auc',
         cv=cv,
         random_state=42,
-        n_jobs=-1,
+        n_jobs=ncores,
         verbose=1
     )
 
@@ -157,9 +157,9 @@ def main(watershed_name):
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print("Usage: python xgboost_gridsearch.py <watershed_name>")
+        print("Usage: python xgboost_gridsearch.py <watershed_name> [ncores]")
         print("\nExample:")
-        print("  python xgboost_gridsearch.py Bear_Creek_1710030801")
+        print("  python xgboost_gridsearch.py Bear_Creek_1710030801 4")
         base_dir = get_repo_root() / "GEE" / "TIF_Output"
         watersheds = [d.name for d in base_dir.iterdir() if d.is_dir() and not d.name.startswith('.')]
         if len(watersheds) == 1:
@@ -169,4 +169,5 @@ if __name__ == "__main__":
             print(f"\nAvailable watersheds: {', '.join(watersheds)}")
             sys.exit(1)
     else:
-        main(sys.argv[1])
+        ncores = int(sys.argv[2]) if len(sys.argv) > 2 else 1
+        main(sys.argv[1], ncores)

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -215,14 +215,14 @@ def main(input_dem, ncores):
     # Step 7: Hyperparameter tuning
     run_step(
         "7. Tune XGBoost Hyperparameters (100 combinations, 5-fold CV)",
-        f"python xgboost_gridsearch.py {watershed_name}",
+        f"python xgboost_gridsearch.py {watershed_name} {ncores}",
         cwd=base_dir / "ModelTraining"
     )
 
     # Step 8: Train model
     run_step(
         "8. Train XGBoost Model (tuned hyperparameters, 75/25 split)",
-        f"python train_xgboost.py {watershed_name}",
+        f"python train_xgboost.py {watershed_name} {ncores}",
         cwd=base_dir / "ModelTraining"
     )
 

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -195,6 +195,16 @@ def main(input_dem, ncores):
         cwd=base_dir / "FeatureStacking"
     )
 
+    # Delete individual feature TIFs now that they're combined into features_stacked.tif
+    output_dir = base_dir / "GEE" / "TIF_Output" / watershed_name
+    keep = {"features_stacked.tif"}
+    deleted = 0
+    for f in output_dir.glob("*.tif"):
+        if f.name not in keep:
+            f.unlink()
+            deleted += 1
+    print(f"  ✓ Deleted {deleted} individual feature TIFs (~{deleted * 50}MB freed)")
+
     # Step 6: Prepare training data
     run_step(
         "6. Prepare Training Data from Wetlands (OR/CA geodatabases)",


### PR DESCRIPTION
## Summary

- **Final output folder**: probability TIFs are now moved to `GEE/TIF_Output/FinalOutput/` with clean names (e.g. `Bear_Creek_Probability.tif`) and all intermediate working files are deleted automatically after each watershed completes
- **In-place NoData fix**: step 0 overwrites the original input DEM instead of creating `_fixed.tif` copies, preventing duplicate files from polluting the TIF_Input directory across runs
- **SLURM array job** (`SLURM/submit_watersheds.slurm`): processes all 119 watersheds in parallel on ORCA — 8 nodes × 16 watersheds each × 4 cores per watershed; skips already-completed watersheds automatically
- **Peak disk reduction**: individual feature TIFs (~1.5GB/watershed) are deleted immediately after stacking instead of at pipeline end, keeping disk usage well under the 100GB home quota
- **XGBoost n_jobs fix**: `RandomizedSearchCV` now parallelizes across CV fits (`n_jobs=ncores`) with single-threaded XGBoost per fit (`n_jobs=1`), preventing 16 concurrent watershed processes from oversubscribing the node's 64 cores
- **MLflow/DagsHub rate-limit fix**: detects `SLURM_JOB_ID` and uses local MLflow tracking instead of DagsHub remote, avoiding 429 errors when 128 watersheds hit the API simultaneously

## Test plan

Run `python run_pipeline.py GEE/TIF_Input/<watershed>.tif` locally and confirm `FinalOutput/<watershed>_Probability.tif` is produced and working directory is cleaned up. Confirm `_fixed.tif` files are no longer created in `TIF_Input/`. Submit `sbatch SLURM/submit_watersheds.slurm` on ORCA and confirm all 8 array tasks complete without disk quota errors or XGBoost hangs.