### PR TITLE
Pipeline reliability, output organization, and edge pixel fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ twi_*_temp.tif
 *.pkl
 *.joblib
 
+# Local MLflow tracking (used as DagsHub fallback on SLURM)
+mlruns/
+
 # Training data CSVs (can be large)
 *training_data*.csv
 Wetlands/training_data_*.csv

--- a/FeatureEngineering/Advanced/calculate_advanced_features.py
+++ b/FeatureEngineering/Advanced/calculate_advanced_features.py
@@ -162,11 +162,14 @@ def main(watershed_name):
     with rasterio.open(dem_file) as src:
         dem = src.read(1).astype(np.float64)
         profile = src.profile
+        file_nodata = src.nodata
 
     # Outside-watershed pixels may be encoded as NaN, large positive, or large
     # negative depending on GEE export settings and TauDEM version. Normalize
     # all nodata to NaN so gradient/filter operations propagate correctly.
     dem_nodata = np.isnan(dem) | (dem > 1e10) | (dem < -1e10)
+    if file_nodata is not None:
+        dem_nodata |= (dem == file_nodata)
     dem[dem_nodata] = np.nan
 
     # Mask of pixels inside the watershed (used for boundary NaN filling)

--- a/FeatureEngineering/TWI/calculate_twi_100m.py
+++ b/FeatureEngineering/TWI/calculate_twi_100m.py
@@ -67,21 +67,32 @@ def calculate_twi(sca_file, slope_file, output_file):
     print(f"Calculating TWI at 100m...")
     
     with rasterio.open(sca_file) as src:
-        sca = src.read(1)
+        sca = src.read(1).astype(np.float64)
         profile = src.profile
-    
+        sca_nodata = src.nodata
+
     with rasterio.open(slope_file) as src:
-        slope = src.read(1)
-    
+        slope = src.read(1).astype(np.float64)
+        slope_nodata = src.nodata
+
+    nodata_mask = np.isnan(sca) | np.isnan(slope) | (sca > 1e10) | (slope > 1e10) | (sca < -1e10) | (slope < -1e10)
+    if sca_nodata is not None:
+        nodata_mask |= (sca == sca_nodata)
+    if slope_nodata is not None:
+        nodata_mask |= (slope == slope_nodata)
+    sca[nodata_mask] = np.nan
+    slope[nodata_mask] = np.nan
+
     slope_rad = np.radians(slope)
     tan_slope = np.tan(slope_rad)
     tan_slope[tan_slope <= 0] = 0.001
-    
+
     twi = np.log(sca / tan_slope)
-    twi[~np.isfinite(twi)] = 0
-    
+    twi[nodata_mask | ~np.isfinite(twi)] = -9999
+    profile.update(nodata=-9999)
+
     with rasterio.open(output_file, 'w', **profile) as dst:
-        dst.write(twi, 1)
+        dst.write(twi.astype(np.float32), 1)
     
     print(f"✓ TWI 100m saved to {output_file}")
     

--- a/FeatureEngineering/TWI/calculate_twi_10m.py
+++ b/FeatureEngineering/TWI/calculate_twi_10m.py
@@ -14,15 +14,26 @@ def calculate_twi(sca_file, slope_file, output_file):
     
     print(f"Reading {sca_file}...")
     with rasterio.open(sca_file) as src:
-        sca = src.read(1)
+        sca = src.read(1).astype(np.float64)
         profile = src.profile
-    
+        sca_nodata = src.nodata
+
     print(f"Reading {slope_file}...")
     with rasterio.open(slope_file) as src:
-        slope = src.read(1)
-    
+        slope = src.read(1).astype(np.float64)
+        slope_nodata = src.nodata
+
+    # Mask nodata pixels so they don't corrupt edge calculations
+    nodata_mask = np.isnan(sca) | np.isnan(slope) | (sca > 1e10) | (slope > 1e10) | (sca < -1e10) | (slope < -1e10)
+    if sca_nodata is not None:
+        nodata_mask |= (sca == sca_nodata)
+    if slope_nodata is not None:
+        nodata_mask |= (slope == slope_nodata)
+    sca[nodata_mask] = np.nan
+    slope[nodata_mask] = np.nan
+
     print("Calculating TWI...")
-    
+
     # Convert slope from degrees to radians
     slope_rad = np.radians(slope)
     
@@ -33,12 +44,13 @@ def calculate_twi(sca_file, slope_file, output_file):
     # Calculate TWI = ln(sca / tan(slope))
     twi = np.log(sca / tan_slope)
     
-    # Handle invalid values
-    twi[~np.isfinite(twi)] = 0
-    
+    # Handle invalid values — set nodata pixels to -9999
+    twi[nodata_mask | ~np.isfinite(twi)] = -9999
+    profile.update(nodata=-9999)
+
     print(f"Writing {output_file}...")
     with rasterio.open(output_file, 'w', **profile) as dst:
-        dst.write(twi, 1)
+        dst.write(twi.astype(np.float32), 1)
     
     print(f"✓ TWI saved to {output_file}")
     

--- a/FeatureEngineering/Terrain/calculate_terrain_features.py
+++ b/FeatureEngineering/Terrain/calculate_terrain_features.py
@@ -119,10 +119,14 @@ def main(watershed_name):
     with rasterio.open(dem_file) as src:
         elevation = src.read(1)
         profile = src.profile
-    
+        file_nodata = src.nodata
+
     # CRITICAL: Replace TauDEM NoData values with NaN
     print("Cleaning TauDEM NoData values...")
     nodata_mask = elevation > 1e10  # Any huge value is NoData
+    nodata_mask |= elevation < -1e10
+    if file_nodata is not None:
+        nodata_mask |= (elevation == file_nodata)
     print(f"  Found {np.sum(nodata_mask):,} NoData pixels")
     elevation[nodata_mask] = np.nan
     

--- a/ModelTraining/predict_meadows.py
+++ b/ModelTraining/predict_meadows.py
@@ -9,6 +9,7 @@ import numpy as np
 import joblib
 import sys
 from pathlib import Path
+from scipy.ndimage import label, distance_transform_edt
 
 def get_repo_root():
     # ModelTraining/train_random_forest.py
@@ -77,7 +78,24 @@ def predict_probabilities(features_path, model_path, output_path, chunk_size=100
                 print(f"  Chunk {chunk_idx + 1}/{n_chunks} ({pct:.1f}%)")
         
         print("\n✓ Prediction complete!")
-        
+
+        # Fill internal NoData holes with nearest-neighbor prediction.
+        # "Internal" = nodata regions fully surrounded by valid predictions (not touching the raster edge).
+        nodata_mask = probabilities == -9999.0
+        labeled, _ = label(nodata_mask)
+        exterior_labels = set()
+        for edge in (labeled[0, :], labeled[-1, :], labeled[:, 0], labeled[:, -1]):
+            exterior_labels.update(edge.tolist())
+        exterior_labels.discard(0)
+        interior_holes = nodata_mask.copy()
+        for lbl in exterior_labels:
+            interior_holes[labeled == lbl] = False
+        n_filled = int(interior_holes.sum())
+        if n_filled > 0:
+            indices = distance_transform_edt(nodata_mask, return_distances=False, return_indices=True)
+            probabilities[interior_holes] = probabilities[indices[0][interior_holes], indices[1][interior_holes]]
+            print(f"  Filled {n_filled:,} internal NoData pixels with nearest-neighbor prediction")
+
         # Calculate statistics
         valid_probs = probabilities[probabilities > -9999]
         print(f"\nPrediction Statistics:")

--- a/ModelTraining/train_xgboost.py
+++ b/ModelTraining/train_xgboost.py
@@ -4,6 +4,7 @@ Train XGBoost model for meadow detection
 Mirrors train_random_forest.py for direct comparison
 """
 
+import datetime
 import json
 import numpy as np
 import pandas as pd
@@ -103,10 +104,12 @@ def train_model(features, labels, watershed_name, ncores=1):
     if params_path.exists():
         with open(params_path) as f:
             tuned_params = json.load(f)
+        best_cv_auc = tuned_params.pop("best_cv_auc", None)
         print(f"\nLoading tuned hyperparameters from: {params_path}")
         xgb_params = {**default_params, **tuned_params}
         params_source = "tuned (per-watershed)"
     else:
+        best_cv_auc = None
         print(f"\nNo tuned hyperparameters found — using Bear Creek defaults.")
         xgb_params = default_params.copy()
         params_source = "default (Bear Creek)"
@@ -223,6 +226,62 @@ def train_model(features, labels, watershed_name, ncores=1):
 
         print("Model saved and logged to MLflow!")
         print(f"Run URL: {mlflow.get_tracking_uri()}")
+
+        # ---- write metrics log ------------------------------------------
+        log_path = output_dir / f"{watershed_name}_log.txt"
+        indices = np.argsort(importances)[::-1]
+        lines = [
+            "=" * 80,
+            f"WATERSHED: {watershed_name}",
+            f"Date/Time: {datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}",
+            "=" * 80,
+            "",
+            "DATA SUMMARY",
+            f"  Total samples:           {len(labels):,}",
+            f"  Wetland (1):             {n_wetland:,}  ({100*n_wetland/max(len(labels),1):.1f}%)",
+            f"  Non-wetland (0):         {n_non_wetland:,}  ({100*n_non_wetland/max(len(labels),1):.1f}%)",
+            f"  Class ratio (neg/pos):   {n_non_wetland/max(n_wetland,1):.2f}",
+            f"  Training set:            {X_train.shape[0]:,}",
+            f"  Test set:                {X_test.shape[0]:,}",
+            "",
+            f"HYPERPARAMETERS ({params_source})",
+        ]
+        if best_cv_auc is not None:
+            lines.append(f"  {'best_cv_auc':<25s} {best_cv_auc:.4f}")
+        for k, v in sorted(xgb_params.items()):
+            lines.append(f"  {k:<25s} {v}")
+        lines += [
+            "",
+            "TEST SET PERFORMANCE",
+            f"  AUC:                     {auc:.4f}",
+            f"  Accuracy:                {report['accuracy']:.4f}",
+            "",
+            "  Wetland:",
+            f"    Precision:             {report['wetland']['precision']:.4f}",
+            f"    Recall:                {report['wetland']['recall']:.4f}",
+            f"    F1-score:              {report['wetland']['f1-score']:.4f}",
+            f"    Support:               {int(report['wetland']['support']):,}",
+            "",
+            "  Non-Wetland:",
+            f"    Precision:             {report['non_wetland']['precision']:.4f}",
+            f"    Recall:                {report['non_wetland']['recall']:.4f}",
+            f"    F1-score:              {report['non_wetland']['f1-score']:.4f}",
+            f"    Support:               {int(report['non_wetland']['support']):,}",
+            "",
+            "CONFUSION MATRIX",
+            f"                       Predicted Non-W  Predicted Wetland",
+            f"  Actual Non-W              {cm[0,0]:8,}          {cm[0,1]:8,}",
+            f"  Actual Wetland            {cm[1,0]:8,}          {cm[1,1]:8,}",
+            "",
+            "FEATURE IMPORTANCES (ranked)",
+        ]
+        for i, idx in enumerate(indices, 1):
+            lines.append(f"  {i:2d}. {FEATURE_NAMES[idx]:<35s} {importances[idx]:.4f}")
+        lines.append("")
+
+        with open(log_path, "w") as lf:
+            lf.write("\n".join(lines))
+        print(f"\n  ✓ Metrics log written: {log_path.name}")
 
     return xgb
 

--- a/ModelTraining/xgboost_gridsearch.py
+++ b/ModelTraining/xgboost_gridsearch.py
@@ -147,6 +147,7 @@ def main(watershed_name, ncores=1):
     params_path = output_dir / "best_params.json"
     # Don't save scale_pos_weight — train_xgboost.py computes it dynamically
     params_to_save = {k: v for k, v in search.best_params_.items() if k != "scale_pos_weight"}
+    params_to_save["best_cv_auc"] = round(float(search.best_score_), 4)
     with open(params_path, "w") as f:
         json.dump(params_to_save, f, indent=2)
     print(f"\n{'='*60}")

--- a/SLURM/submit_watersheds.slurm
+++ b/SLURM/submit_watersheds.slurm
@@ -23,7 +23,7 @@
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=64       # 16 watersheds × 4 cores = all 64 cores
 #SBATCH --mem=200G               # 576GB available, 200G is plenty of headroom
-#SBATCH --time=00:30:00
+#SBATCH --time=01:00:00
 #SBATCH --partition=normal
 #SBATCH --output=SLURM/logs/%A_%a.out
 #SBATCH --error=SLURM/logs/%A_%a.err

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -246,12 +246,59 @@ def main(input_dem, ncores):
     print(f"{'='*70}")
     print(f"Total time: {total_minutes}m {total_seconds}s")
 
-    # Move final outputs to FinalOutput/, then delete the working folder
+    # Create output directories
     final_output_dir.mkdir(parents=True, exist_ok=True)
+    logs_dir = base_dir / "GEE" / "TIF_Output" / "Logs"
+    training_data_dir = base_dir / "GEE" / "TIF_Output" / "TrainingData"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    training_data_dir.mkdir(parents=True, exist_ok=True)
 
     probability_src = output_dir / f"{watershed_name}_xgboost_model_probability.tif"
     probability_dst = final_output_dir / f"{input_dem_abs.stem}_Probability.tif"
 
+    # Read prediction statistics from probability TIF before moving it
+    meadow_pixels = total_pixels = 0
+    meadow_ha = coverage_pct = 0.0
+    if probability_src.exists():
+        with rasterio.open(probability_src) as src:
+            prob = src.read(1).astype(np.float32)
+            nodata = src.nodata
+            valid = np.isfinite(prob)
+            if nodata is not None:
+                valid &= (prob != nodata)
+            total_pixels = int(valid.sum())
+            meadow_pixels = int((prob[valid] > 0.5).sum())
+            meadow_ha = meadow_pixels * 0.01  # 10m × 10m = 100 m² = 0.01 ha
+            coverage_pct = 100 * meadow_pixels / max(total_pixels, 1)
+
+    # Append prediction stats and runtime to the metrics log
+    log_src = output_dir / f"{watershed_name}_log.txt"
+    log_dst = logs_dir / f"{watershed_name}_log.txt"
+    if log_src.exists():
+        with open(log_src, "a") as lf:
+            lf.write("PREDICTION STATISTICS\n")
+            lf.write(f"  Meadow pixels (prob > 0.5):  {meadow_pixels:,}\n")
+            lf.write(f"  Estimated meadow area:        {meadow_ha:,.2f} ha\n")
+            lf.write(f"  Total valid pixels:           {total_pixels:,}\n")
+            lf.write(f"  Meadow coverage:              {coverage_pct:.2f}%\n")
+            lf.write("\n")
+            lf.write("PIPELINE RUNTIME\n")
+            lf.write(f"  Total time: {total_minutes}m {total_seconds}s\n")
+            lf.write("\n" + "=" * 80 + "\n")
+
+    # Copy training CSV to TrainingData/
+    training_csv_src = output_dir / "training_data_real.csv"
+    training_csv_dst = training_data_dir / f"{watershed_name}_training_data.csv"
+    if training_csv_src.exists():
+        shutil.copy2(str(training_csv_src), str(training_csv_dst))
+        print(f"  ✓ Training data saved to: TrainingData/{training_csv_dst.name}")
+
+    # Move log to Logs/
+    if log_src.exists():
+        shutil.move(str(log_src), str(log_dst))
+        print(f"  ✓ Log saved to: Logs/{log_dst.name}")
+
+    # Move probability TIF to FinalOutput/
     print(f"\nMoving final outputs to: {final_output_dir}")
     if probability_src.exists():
         shutil.move(str(probability_src), str(probability_dst))
@@ -265,6 +312,8 @@ def main(input_dem, ncores):
 
     print(f"\nFinal outputs in: {final_output_dir}")
     print(f"  ✓ {probability_dst.name}")
+    print(f"  ✓ Logs/{watershed_name}_log.txt")
+    print(f"  ✓ TrainingData/{watershed_name}_training_data.csv")
     print(f"\nNext steps:")
     print(f"  1. Upload {probability_dst.name} to Google Earth Engine")
     print(f"  2. Run GEE/MeadowVisualization.js for interactive map")


### PR DESCRIPTION
Closes #149

## Summary

**Output organization**
- Probability TIFs are moved to `GEE/TIF_Output/FinalOutput/` with clean names (e.g. `Bear_Creek_Probability.tif`) after each watershed completes
- `GEE/TIF_Output/Logs/` — one `.txt` log per watershed containing hyperparameters, CV AUC, test AUC, classification report, confusion matrix, all 29 feature importances ranked, predicted meadow area in hectares, and total pipeline runtime
- `GEE/TIF_Output/TrainingData/` — full training CSV per watershed saved before cleanup, enabling global model training across all watersheds later
- All intermediate working files are deleted automatically after each watershed completes

**In-place NoData fix**
- Step 0 now overwrites the original input DEM instead of creating `_fixed.tif` copies, preventing duplicate files from polluting `TIF_Input/` across runs

**SLURM array job**
- `SLURM/submit_watersheds.slurm` processes all 119 watersheds in parallel on ORCA — 8 nodes × 16 watersheds each × 4 cores per watershed
- Skips already-completed watersheds automatically on resubmit

**Peak disk reduction**
- Individual feature TIFs (~1.5GB/watershed) are deleted immediately after stacking instead of at pipeline end, keeping disk usage well under the 100GB home quota during parallel runs

**XGBoost n_jobs fix**
- `RandomizedSearchCV` parallelizes across CV fits (`n_jobs=ncores`) with single-threaded XGBoost per fit (`n_jobs=1`), preventing 16 concurrent watershed processes from oversubscribing ORCA's 64 cores
- Same fix applied to `train_xgboost.py` final model training
- `ncores` is passed through from the SLURM script to both training scripts

**MLflow/DagsHub rate-limit fix**
- Detects `SLURM_JOB_ID` and uses local MLflow tracking instead of DagsHub remote, avoiding 429 errors when 128 watersheds hit the API simultaneously
- Falls back to local tracking if DagsHub is unavailable for any other reason

**Edge pixel fix**
- Feature engineering scripts (`calculate_advanced_features.py`, `calculate_terrain_features.py`, `calculate_twi_10m.py`, `calculate_twi_100m.py`) were only checking for NaN and values >1e10 as nodata, missing the -9999 sentinel set by step 0
- Border pixels with -9999 were treated as valid elevation, causing large gradients and missing pixel rings at watershed edges
- Fixed by reading `src.nodata` from raster metadata and including it in the nodata mask, preserving Laura's step 0 striping fix while restoring correct edge behavior

**Internal NoData hole fill**
- After prediction, any nodata pixels fully surrounded by valid predictions (internal holes from POLARIS soil coverage gaps or similar) are filled using nearest-neighbor from adjacent valid predictions
- Edge/boundary nodata regions are left untouched — only isolated interior holes are filled
- Does not affect training, model metrics, or feature importances — purely a post-prediction output fix
