### PR TITLE
Add watershed training logs for no-elevation run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ Wetlands/wetlands_PEM_PSS_PFO_bioregion.shx
 
 # Output directories with generated data
 GEE/TIF_Output/*/
+!GEE/TIF_Output/Logs/
+!GEE/TIF_Output/Logs/**
 GEE/TIF_Output/1/
 GEE/TIF_Output/2/
 

--- a/GEE/TIF_Output/Logs/Althouse_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Althouse_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Althouse_Creek
+Date/Time: 2026-04-29 16:38:11
+================================================================================
+
+DATA SUMMARY
+  Total samples:           88,135
+  Wetland (1):             17,627  (20.0%)
+  Non-wetland (0):         70,508  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            66,101
+  Test set:                22,034
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9527
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0001
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9738
+  Accuracy:                0.9145
+
+  Wetland:
+    Precision:             0.7271
+    Recall:                0.9170
+    F1-score:              0.8110
+    Support:               4,407
+
+  Non-Wetland:
+    Precision:             0.9778
+    Recall:                0.9139
+    F1-score:              0.9448
+    Support:               17,627
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                16,110             1,517
+  Actual Wetland                 366             4,041
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.1935
+   2. tri                                 0.0828
+   3. elev_std_9x9                        0.0657
+   4. tpi_21x21                           0.0652
+   5. elev_5x5_std_dev                    0.0506
+   6. soil_organic_matter_0_5cm           0.0496
+   7. soil_ksat_0_5cm                     0.0388
+   8. soil_organic_matter_15_30cm         0.0369
+   9. soil_organic_matter_5_15cm          0.0349
+  10. dd_h                                0.0317
+  11. soil_clay_pct_15_30cm               0.0304
+  12. twi_100m                            0.0270
+  13. twi_10m                             0.0236
+  14. soil_ksat_5_15cm                    0.0236
+  15. soil_clay_pct_5_15cm                0.0234
+  16. soil_ksat_15_30cm                   0.0227
+  17. soil_clay_pct_0_5cm                 0.0226
+  18. dd_s                                0.0223
+  19. slope_std_9x9                       0.0205
+  20. slope_5x5_std_dev                   0.0203
+  21. elev_std_3x3                        0.0198
+  22. aspect                              0.0188
+  23. tpi_11x11                           0.0158
+  24. curvature_plan                      0.0132
+  25. elev_5x5_rel                        0.0132
+  26. slope                               0.0127
+  27. curvature_profile                   0.0106
+  28. tpi_3x3                             0.0098
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  116,022
+  Estimated meadow area:        1,160.22 ha
+  Total valid pixels:           1,227,587
+  Meadow coverage:              9.45%
+
+PIPELINE RUNTIME
+  Total time: 10m 24s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Badger_Basin_Willow_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Badger_Basin_Willow_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Badger_Basin_Willow_Creek
+Date/Time: 2026-04-29 16:38:31
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9935
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9961
+  Accuracy:                0.9738
+
+  Wetland:
+    Precision:             0.9000
+    Recall:                0.9774
+    F1-score:              0.9371
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9942
+    Recall:                0.9728
+    F1-score:              0.9834
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,457               543
+  Actual Wetland                 113             4,887
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.2553
+   2. elev_5x5_std_dev                    0.1252
+   3. soil_ksat_0_5cm                     0.1242
+   4. tri                                 0.1070
+   5. soil_organic_matter_15_30cm         0.0446
+   6. soil_ksat_5_15cm                    0.0418
+   7. soil_clay_pct_15_30cm               0.0415
+   8. slope                               0.0240
+   9. soil_clay_pct_0_5cm                 0.0228
+  10. soil_organic_matter_5_15cm          0.0223
+  11. soil_clay_pct_5_15cm                0.0201
+  12. slope_std_9x9                       0.0201
+  13. soil_ksat_15_30cm                   0.0189
+  14. slope_5x5_std_dev                   0.0186
+  15. dd_v                                0.0175
+  16. elev_std_3x3                        0.0164
+  17. soil_organic_matter_0_5cm           0.0150
+  18. aspect                              0.0099
+  19. tpi_21x21                           0.0095
+  20. twi_100m                            0.0078
+  21. dd_h                                0.0076
+  22. dd_s                                0.0064
+  23. twi_10m                             0.0056
+  24. tpi_11x11                           0.0049
+  25. curvature_plan                      0.0042
+  26. elev_5x5_rel                        0.0035
+  27. tpi_3x3                             0.0027
+  28. curvature_profile                   0.0026
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  164,844
+  Estimated meadow area:        1,648.44 ha
+  Total valid pixels:           3,480,975
+  Meadow coverage:              4.74%
+
+PIPELINE RUNTIME
+  Total time: 10m 47s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Bear_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Bear_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Bear_Creek
+Date/Time: 2026-04-29 16:39:18
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9351
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9554
+  Accuracy:                0.8846
+
+  Wetland:
+    Precision:             0.6543
+    Recall:                0.8968
+    F1-score:              0.7566
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9716
+    Recall:                0.8815
+    F1-score:              0.9244
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                17,631             2,369
+  Actual Wetland                 516             4,484
+
+FEATURE IMPORTANCES (ranked)
+   1. tpi_21x21                           0.1525
+   2. soil_ksat_15_30cm                   0.0757
+   3. slope                               0.0512
+   4. elev_5x5_std_dev                    0.0470
+   5. soil_clay_pct_0_5cm                 0.0467
+   6. elev_5x5_rel                        0.0426
+   7. twi_10m                             0.0412
+   8. elev_std_3x3                        0.0380
+   9. tpi_11x11                           0.0364
+  10. elev_std_9x9                        0.0345
+  11. soil_clay_pct_5_15cm                0.0335
+  12. soil_organic_matter_15_30cm         0.0320
+  13. curvature_profile                   0.0297
+  14. twi_100m                            0.0291
+  15. dd_h                                0.0285
+  16. dd_v                                0.0274
+  17. tri                                 0.0272
+  18. soil_ksat_5_15cm                    0.0260
+  19. dd_s                                0.0253
+  20. soil_clay_pct_15_30cm               0.0241
+  21. soil_organic_matter_5_15cm          0.0215
+  22. aspect                              0.0215
+  23. soil_ksat_0_5cm                     0.0200
+  24. soil_organic_matter_0_5cm           0.0188
+  25. slope_std_9x9                       0.0184
+  26. tpi_3x3                             0.0178
+  27. slope_5x5_std_dev                   0.0168
+  28. curvature_plan                      0.0164
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  1,162,491
+  Estimated meadow area:        11,624.91 ha
+  Total valid pixels:           9,368,969
+  Meadow coverage:              12.41%
+
+PIPELINE RUNTIME
+  Total time: 11m 39s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Beaver_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Beaver_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Beaver_Creek
+Date/Time: 2026-04-29 16:38:43
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9303
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9686
+  Accuracy:                0.9211
+
+  Wetland:
+    Precision:             0.7634
+    Recall:                0.8776
+    F1-score:              0.8165
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9682
+    Recall:                0.9320
+    F1-score:              0.9498
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                18,640             1,360
+  Actual Wetland                 612             4,388
+
+FEATURE IMPORTANCES (ranked)
+   1. tpi_21x21                           0.1698
+   2. twi_10m                             0.1186
+   3. elev_std_9x9                        0.0849
+   4. soil_organic_matter_15_30cm         0.0580
+   5. dd_v                                0.0403
+   6. dd_h                                0.0397
+   7. twi_100m                            0.0390
+   8. aspect                              0.0347
+   9. dd_s                                0.0319
+  10. soil_clay_pct_0_5cm                 0.0318
+  11. soil_clay_pct_5_15cm                0.0295
+  12. soil_ksat_5_15cm                    0.0295
+  13. soil_organic_matter_0_5cm           0.0269
+  14. soil_clay_pct_15_30cm               0.0266
+  15. slope_std_9x9                       0.0240
+  16. soil_organic_matter_5_15cm          0.0222
+  17. soil_ksat_15_30cm                   0.0220
+  18. soil_ksat_0_5cm                     0.0211
+  19. elev_5x5_std_dev                    0.0196
+  20. tpi_11x11                           0.0155
+  21. slope                               0.0153
+  22. tri                                 0.0153
+  23. slope_5x5_std_dev                   0.0151
+  24. curvature_profile                   0.0145
+  25. elev_std_3x3                        0.0145
+  26. tpi_3x3                             0.0140
+  27. elev_5x5_rel                        0.0129
+  28. curvature_plan                      0.0128
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  228,665
+  Estimated meadow area:        2,286.65 ha
+  Total valid pixels:           2,823,711
+  Meadow coverage:              8.10%
+
+PIPELINE RUNTIME
+  Total time: 10m 55s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Beaver_Marsh_log.txt
+++ b/GEE/TIF_Output/Logs/Beaver_Marsh_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Beaver_Marsh
+Date/Time: 2026-04-29 16:38:51
+================================================================================
+
+DATA SUMMARY
+  Total samples:           63,495
+  Wetland (1):             12,699  (20.0%)
+  Non-wetland (0):         50,796  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            47,621
+  Test set:                15,874
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9871
+  colsample_bytree          1.0
+  gamma                     0.1
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              100
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                1
+  scale_pos_weight          4.0001
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9958
+  Accuracy:                0.9722
+
+  Wetland:
+    Precision:             0.8960
+    Recall:                0.9739
+    F1-score:              0.9333
+    Support:               3,175
+
+  Non-Wetland:
+    Precision:             0.9933
+    Recall:                0.9717
+    F1-score:              0.9824
+    Support:               12,699
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                12,340               359
+  Actual Wetland                  83             3,092
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_s                                0.2509
+   2. tpi_21x21                           0.1345
+   3. dd_v                                0.0765
+   4. soil_organic_matter_15_30cm         0.0558
+   5. soil_organic_matter_0_5cm           0.0527
+   6. slope_5x5_std_dev                   0.0414
+   7. soil_clay_pct_15_30cm               0.0275
+   8. elev_std_9x9                        0.0262
+   9. slope                               0.0258
+  10. twi_100m                            0.0251
+  11. slope_std_9x9                       0.0221
+  12. dd_h                                0.0220
+  13. elev_5x5_std_dev                    0.0219
+  14. soil_clay_pct_5_15cm                0.0213
+  15. soil_clay_pct_0_5cm                 0.0201
+  16. curvature_plan                      0.0190
+  17. aspect                              0.0177
+  18. soil_organic_matter_5_15cm          0.0170
+  19. twi_10m                             0.0166
+  20. tri                                 0.0159
+  21. soil_ksat_0_5cm                     0.0153
+  22. elev_std_3x3                        0.0148
+  23. soil_ksat_15_30cm                   0.0122
+  24. tpi_11x11                           0.0115
+  25. soil_ksat_5_15cm                    0.0111
+  26. curvature_profile                   0.0087
+  27. tpi_3x3                             0.0087
+  28. elev_5x5_rel                        0.0080
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  235,419
+  Estimated meadow area:        2,354.19 ha
+  Total valid pixels:           8,125,619
+  Meadow coverage:              2.90%
+
+PIPELINE RUNTIME
+  Total time: 11m 11s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Big_Butte_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Big_Butte_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Big_Butte_Creek
+Date/Time: 2026-04-29 16:38:54
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9789
+  colsample_bytree          0.8
+  gamma                     1.0
+  learning_rate             0.1
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.1
+  reg_lambda                1.5
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9921
+  Accuracy:                0.9620
+
+  Wetland:
+    Precision:             0.8745
+    Recall:                0.9460
+    F1-score:              0.9088
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9862
+    Recall:                0.9660
+    F1-score:              0.9760
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,321               679
+  Actual Wetland                 270             4,730
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.2303
+   2. elev_5x5_std_dev                    0.1868
+   3. soil_clay_pct_5_15cm                0.1197
+   4. dd_v                                0.0653
+   5. soil_organic_matter_15_30cm         0.0306
+   6. twi_100m                            0.0298
+   7. tpi_21x21                           0.0248
+   8. elev_std_3x3                        0.0245
+   9. dd_s                                0.0214
+  10. soil_clay_pct_0_5cm                 0.0196
+  11. soil_ksat_15_30cm                   0.0193
+  12. dd_h                                0.0193
+  13. soil_clay_pct_15_30cm               0.0191
+  14. soil_ksat_0_5cm                     0.0179
+  15. slope                               0.0172
+  16. soil_organic_matter_5_15cm          0.0149
+  17. aspect                              0.0143
+  18. soil_organic_matter_0_5cm           0.0142
+  19. soil_ksat_5_15cm                    0.0141
+  20. twi_10m                             0.0138
+  21. slope_std_9x9                       0.0133
+  22. tri                                 0.0129
+  23. tpi_11x11                           0.0117
+  24. curvature_plan                      0.0114
+  25. slope_5x5_std_dev                   0.0096
+  26. curvature_profile                   0.0092
+  27. elev_5x5_rel                        0.0083
+  28. tpi_3x3                             0.0067
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  242,508
+  Estimated meadow area:        2,425.08 ha
+  Total valid pixels:           6,411,785
+  Meadow coverage:              3.78%
+
+PIPELINE RUNTIME
+  Total time: 11m 14s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Big_Springs_Creek_Klamath_Marsh_log.txt
+++ b/GEE/TIF_Output/Logs/Big_Springs_Creek_Klamath_Marsh_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Big_Springs_Creek_Klamath_Marsh
+Date/Time: 2026-04-29 16:38:30
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9960
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9975
+  Accuracy:                0.9802
+
+  Wetland:
+    Precision:             0.9171
+    Recall:                0.9906
+    F1-score:              0.9524
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9976
+    Recall:                0.9776
+    F1-score:              0.9875
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,552               448
+  Actual Wetland                  47             4,953
+
+FEATURE IMPORTANCES (ranked)
+   1. soil_clay_pct_5_15cm                0.5591
+   2. soil_clay_pct_15_30cm               0.2226
+   3. soil_clay_pct_0_5cm                 0.1153
+   4. soil_ksat_15_30cm                   0.0191
+   5. soil_organic_matter_15_30cm         0.0140
+   6. soil_organic_matter_0_5cm           0.0062
+   7. soil_ksat_5_15cm                    0.0052
+   8. dd_v                                0.0048
+   9. slope_5x5_std_dev                   0.0046
+  10. slope_std_9x9                       0.0040
+  11. dd_s                                0.0038
+  12. soil_ksat_0_5cm                     0.0038
+  13. soil_organic_matter_5_15cm          0.0038
+  14. twi_100m                            0.0038
+  15. dd_h                                0.0036
+  16. elev_std_9x9                        0.0032
+  17. tpi_21x21                           0.0027
+  18. elev_5x5_std_dev                    0.0026
+  19. aspect                              0.0021
+  20. elev_std_3x3                        0.0020
+  21. twi_10m                             0.0020
+  22. tri                                 0.0020
+  23. tpi_11x11                           0.0017
+  24. curvature_plan                      0.0017
+  25. slope                               0.0017
+  26. elev_5x5_rel                        0.0016
+  27. curvature_profile                   0.0015
+  28. tpi_3x3                             0.0014
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  274,679
+  Estimated meadow area:        2,746.79 ha
+  Total valid pixels:           2,598,538
+  Meadow coverage:              10.57%
+
+PIPELINE RUNTIME
+  Total time: 10m 44s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Bogus_Creek_Klamath_River_log.txt
+++ b/GEE/TIF_Output/Logs/Bogus_Creek_Klamath_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Bogus_Creek_Klamath_River
+Date/Time: 2026-04-29 16:38:43
+================================================================================
+
+DATA SUMMARY
+  Total samples:           63,010
+  Wetland (1):             12,602  (20.0%)
+  Non-wetland (0):         50,408  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            47,257
+  Test set:                15,753
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9187
+  colsample_bytree          1.0
+  gamma                     0.5
+  learning_rate             0.1
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                1.5
+  scale_pos_weight          4.0002
+  subsample                 0.6
+
+TEST SET PERFORMANCE
+  AUC:                     0.9737
+  Accuracy:                0.9280
+
+  Wetland:
+    Precision:             0.7830
+    Recall:                0.8851
+    F1-score:              0.8309
+    Support:               3,151
+
+  Non-Wetland:
+    Precision:             0.9703
+    Recall:                0.9387
+    F1-score:              0.9542
+    Support:               12,602
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                11,829               773
+  Actual Wetland                 362             2,789
+
+FEATURE IMPORTANCES (ranked)
+   1. tpi_21x21                           0.1308
+   2. elev_5x5_std_dev                    0.0862
+   3. soil_clay_pct_5_15cm                0.0462
+   4. soil_ksat_5_15cm                    0.0436
+   5. elev_std_9x9                        0.0404
+   6. soil_ksat_0_5cm                     0.0385
+   7. aspect                              0.0370
+   8. dd_v                                0.0337
+   9. twi_100m                            0.0335
+  10. soil_organic_matter_0_5cm           0.0331
+  11. dd_h                                0.0323
+  12. dd_s                                0.0310
+  13. slope_std_9x9                       0.0307
+  14. twi_10m                             0.0300
+  15. soil_clay_pct_0_5cm                 0.0299
+  16. soil_ksat_15_30cm                   0.0295
+  17. soil_clay_pct_15_30cm               0.0286
+  18. soil_organic_matter_5_15cm          0.0286
+  19. tri                                 0.0276
+  20. soil_organic_matter_15_30cm         0.0273
+  21. slope_5x5_std_dev                   0.0259
+  22. tpi_11x11                           0.0255
+  23. slope                               0.0244
+  24. elev_std_3x3                        0.0238
+  25. curvature_profile                   0.0224
+  26. curvature_plan                      0.0213
+  27. elev_5x5_rel                        0.0192
+  28. tpi_3x3                             0.0189
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  306,163
+  Estimated meadow area:        3,061.63 ha
+  Total valid pixels:           4,518,493
+  Meadow coverage:              6.78%
+
+PIPELINE RUNTIME
+  Total time: 10m 59s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Briggs_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Briggs_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Briggs_Creek
+Date/Time: 2026-04-29 16:38:11
+================================================================================
+
+DATA SUMMARY
+  Total samples:           19,830
+  Wetland (1):             3,966  (20.0%)
+  Non-wetland (0):         15,864  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            14,872
+  Test set:                4,958
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9853
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0007
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9910
+  Accuracy:                0.9617
+
+  Wetland:
+    Precision:             0.8856
+    Recall:                0.9284
+    F1-score:              0.9065
+    Support:               992
+
+  Non-Wetland:
+    Precision:             0.9819
+    Recall:                0.9700
+    F1-score:              0.9759
+    Support:               3,966
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 3,847               119
+  Actual Wetland                  71               921
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.6970
+   2. twi_100m                            0.0413
+   3. tri                                 0.0373
+   4. dd_s                                0.0213
+   5. elev_5x5_std_dev                    0.0180
+   6. slope_std_9x9                       0.0175
+   7. tpi_21x21                           0.0166
+   8. elev_std_9x9                        0.0142
+   9. soil_clay_pct_5_15cm                0.0100
+  10. dd_h                                0.0090
+  11. aspect                              0.0088
+  12. soil_organic_matter_15_30cm         0.0087
+  13. soil_ksat_0_5cm                     0.0085
+  14. soil_clay_pct_0_5cm                 0.0082
+  15. curvature_profile                   0.0081
+  16. soil_organic_matter_0_5cm           0.0078
+  17. soil_organic_matter_5_15cm          0.0073
+  18. soil_ksat_15_30cm                   0.0072
+  19. soil_clay_pct_15_30cm               0.0067
+  20. slope                               0.0063
+  21. twi_10m                             0.0063
+  22. curvature_plan                      0.0063
+  23. slope_5x5_std_dev                   0.0055
+  24. elev_std_3x3                        0.0053
+  25. tpi_11x11                           0.0047
+  26. soil_ksat_5_15cm                    0.0044
+  27. elev_5x5_rel                        0.0041
+  28. tpi_3x3                             0.0039
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  60,629
+  Estimated meadow area:        606.29 ha
+  Total valid pixels:           1,774,675
+  Meadow coverage:              3.42%
+
+PIPELINE RUNTIME
+  Total time: 10m 26s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Butte_Valley_log.txt
+++ b/GEE/TIF_Output/Logs/Butte_Valley_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Butte_Valley
+Date/Time: 2026-04-29 16:46:41
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9486
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9722
+  Accuracy:                0.9158
+
+  Wetland:
+    Precision:             0.7315
+    Recall:                0.9150
+    F1-score:              0.8130
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9773
+    Recall:                0.9161
+    F1-score:              0.9457
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                18,321             1,679
+  Actual Wetland                 425             4,575
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.2145
+   2. soil_ksat_0_5cm                     0.0695
+   3. tri                                 0.0614
+   4. elev_std_3x3                        0.0584
+   5. elev_5x5_std_dev                    0.0475
+   6. soil_clay_pct_0_5cm                 0.0431
+   7. soil_clay_pct_5_15cm                0.0362
+   8. slope                               0.0343
+   9. twi_10m                             0.0311
+  10. soil_organic_matter_5_15cm          0.0310
+  11. soil_ksat_5_15cm                    0.0302
+  12. dd_h                                0.0298
+  13. dd_s                                0.0297
+  14. soil_organic_matter_0_5cm           0.0297
+  15. soil_organic_matter_15_30cm         0.0293
+  16. soil_clay_pct_15_30cm               0.0272
+  17. soil_ksat_15_30cm                   0.0254
+  18. aspect                              0.0243
+  19. twi_100m                            0.0233
+  20. tpi_21x21                           0.0222
+  21. slope_std_9x9                       0.0218
+  22. elev_std_9x9                        0.0196
+  23. slope_5x5_std_dev                   0.0131
+  24. tpi_11x11                           0.0114
+  25. elev_5x5_rel                        0.0112
+  26. tpi_3x3                             0.0097
+  27. curvature_plan                      0.0077
+  28. curvature_profile                   0.0073
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  660,453
+  Estimated meadow area:        6,604.53 ha
+  Total valid pixels:           6,536,024
+  Meadow coverage:              10.10%
+
+PIPELINE RUNTIME
+  Total time: 18m 56s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Calapooya_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Calapooya_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Calapooya_Creek
+Date/Time: 2026-04-29 16:39:18
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9592
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9678
+  Accuracy:                0.9046
+
+  Wetland:
+    Precision:             0.6983
+    Recall:                0.9212
+    F1-score:              0.7944
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9786
+    Recall:                0.9005
+    F1-score:              0.9379
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                18,010             1,990
+  Actual Wetland                 394             4,606
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_5x5_std_dev                    0.2847
+   2. elev_std_9x9                        0.1785
+   3. tri                                 0.0738
+   4. dd_v                                0.0717
+   5. elev_std_3x3                        0.0499
+   6. tpi_21x21                           0.0331
+   7. slope                               0.0320
+   8. soil_clay_pct_0_5cm                 0.0276
+   9. soil_clay_pct_15_30cm               0.0199
+  10. soil_clay_pct_5_15cm                0.0192
+  11. twi_100m                            0.0163
+  12. soil_organic_matter_15_30cm         0.0156
+  13. soil_ksat_0_5cm                     0.0141
+  14. soil_ksat_5_15cm                    0.0140
+  15. soil_organic_matter_0_5cm           0.0138
+  16. dd_h                                0.0135
+  17. soil_organic_matter_5_15cm          0.0134
+  18. tpi_11x11                           0.0116
+  19. dd_s                                0.0113
+  20. slope_std_9x9                       0.0110
+  21. slope_5x5_std_dev                   0.0109
+  22. soil_ksat_15_30cm                   0.0107
+  23. twi_10m                             0.0104
+  24. elev_5x5_rel                        0.0096
+  25. curvature_plan                      0.0092
+  26. aspect                              0.0091
+  27. curvature_profile                   0.0077
+  28. tpi_3x3                             0.0074
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  797,318
+  Estimated meadow area:        7,973.18 ha
+  Total valid pixels:           6,381,795
+  Meadow coverage:              12.49%
+
+PIPELINE RUNTIME
+  Total time: 11m 34s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Canton_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Canton_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Canton_Creek
+Date/Time: 2026-04-29 16:38:11
+================================================================================
+
+DATA SUMMARY
+  Total samples:           7,830
+  Wetland (1):             1,566  (20.0%)
+  Non-wetland (0):         6,264  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            5,872
+  Test set:                1,958
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9881
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0017
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9878
+  Accuracy:                0.9586
+
+  Wetland:
+    Precision:             0.8783
+    Recall:                0.9209
+    F1-score:              0.8991
+    Support:               392
+
+  Non-Wetland:
+    Precision:             0.9800
+    Recall:                0.9681
+    F1-score:              0.9740
+    Support:               1,566
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 1,516                50
+  Actual Wetland                  31               361
+
+FEATURE IMPORTANCES (ranked)
+   1. tpi_21x21                           0.2804
+   2. elev_std_9x9                        0.0911
+   3. soil_clay_pct_0_5cm                 0.0449
+   4. dd_v                                0.0419
+   5. twi_100m                            0.0367
+   6. aspect                              0.0363
+   7. dd_h                                0.0362
+   8. soil_organic_matter_15_30cm         0.0353
+   9. dd_s                                0.0348
+  10. elev_std_3x3                        0.0330
+  11. tri                                 0.0309
+  12. elev_5x5_std_dev                    0.0302
+  13. twi_10m                             0.0208
+  14. soil_clay_pct_5_15cm                0.0207
+  15. soil_ksat_15_30cm                   0.0193
+  16. soil_clay_pct_15_30cm               0.0187
+  17. slope_std_9x9                       0.0187
+  18. curvature_plan                      0.0184
+  19. slope_5x5_std_dev                   0.0183
+  20. curvature_profile                   0.0181
+  21. soil_organic_matter_5_15cm          0.0174
+  22. elev_5x5_rel                        0.0172
+  23. soil_ksat_5_15cm                    0.0168
+  24. tpi_11x11                           0.0167
+  25. slope                               0.0156
+  26. tpi_3x3                             0.0113
+  27. soil_ksat_0_5cm                     0.0108
+  28. soil_organic_matter_0_5cm           0.0094
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  62,446
+  Estimated meadow area:        624.46 ha
+  Total valid pixels:           1,647,212
+  Meadow coverage:              3.79%
+
+PIPELINE RUNTIME
+  Total time: 10m 25s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Chetco_River_log.txt
+++ b/GEE/TIF_Output/Logs/Chetco_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Chetco_River
+Date/Time: 2026-04-29 16:39:18
+================================================================================
+
+DATA SUMMARY
+  Total samples:           32,450
+  Wetland (1):             6,490  (20.0%)
+  Non-wetland (0):         25,960  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            24,337
+  Test set:                8,113
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9793
+  colsample_bytree          1.0
+  gamma                     0.1
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              100
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                1
+  scale_pos_weight          4.0004
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9880
+  Accuracy:                0.9546
+
+  Wetland:
+    Precision:             0.8617
+    Recall:                0.9211
+    F1-score:              0.8904
+    Support:               1,623
+
+  Non-Wetland:
+    Precision:             0.9799
+    Recall:                0.9630
+    F1-score:              0.9714
+    Support:               6,490
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 6,250               240
+  Actual Wetland                 128             1,495
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.4594
+   2. slope                               0.0725
+   3. elev_std_9x9                        0.0561
+   4. slope_5x5_std_dev                   0.0389
+   5. tpi_21x21                           0.0378
+   6. twi_100m                            0.0313
+   7. elev_5x5_std_dev                    0.0292
+   8. slope_std_9x9                       0.0177
+   9. soil_organic_matter_15_30cm         0.0161
+  10. dd_h                                0.0157
+  11. soil_ksat_0_5cm                     0.0148
+  12. soil_clay_pct_15_30cm               0.0146
+  13. aspect                              0.0144
+  14. curvature_plan                      0.0140
+  15. soil_ksat_15_30cm                   0.0140
+  16. soil_ksat_5_15cm                    0.0137
+  17. soil_clay_pct_0_5cm                 0.0136
+  18. soil_clay_pct_5_15cm                0.0134
+  19. elev_std_3x3                        0.0132
+  20. soil_organic_matter_5_15cm          0.0130
+  21. tpi_11x11                           0.0126
+  22. tri                                 0.0124
+  23. dd_s                                0.0123
+  24. soil_organic_matter_0_5cm           0.0117
+  25. twi_10m                             0.0103
+  26. elev_5x5_rel                        0.0094
+  27. tpi_3x3                             0.0091
+  28. curvature_profile                   0.0090
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  338,358
+  Estimated meadow area:        3,383.58 ha
+  Total valid pixels:           9,121,267
+  Meadow coverage:              3.71%
+
+PIPELINE RUNTIME
+  Total time: 11m 33s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Clark_Branch_South_Umpqua_River_log.txt
+++ b/GEE/TIF_Output/Logs/Clark_Branch_South_Umpqua_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Clark_Branch_South_Umpqua_River
+Date/Time: 2026-04-29 16:38:43
+================================================================================
+
+DATA SUMMARY
+  Total samples:           79,200
+  Wetland (1):             15,840  (20.0%)
+  Non-wetland (0):         63,360  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            59,400
+  Test set:                19,800
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9713
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9942
+  Accuracy:                0.9686
+
+  Wetland:
+    Precision:             0.8947
+    Recall:                0.9553
+    F1-score:              0.9240
+    Support:               3,960
+
+  Non-Wetland:
+    Precision:             0.9886
+    Recall:                0.9719
+    F1-score:              0.9802
+    Support:               15,840
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                15,395               445
+  Actual Wetland                 177             3,783
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.3456
+   2. dd_v                                0.0596
+   3. soil_ksat_15_30cm                   0.0420
+   4. twi_100m                            0.0372
+   5. soil_organic_matter_5_15cm          0.0337
+   6. tpi_21x21                           0.0324
+   7. dd_s                                0.0312
+   8. dd_h                                0.0286
+   9. twi_10m                             0.0283
+  10. soil_organic_matter_0_5cm           0.0265
+  11. soil_ksat_5_15cm                    0.0261
+  12. slope_std_9x9                       0.0257
+  13. tpi_11x11                           0.0251
+  14. soil_clay_pct_15_30cm               0.0251
+  15. soil_organic_matter_15_30cm         0.0247
+  16. soil_clay_pct_0_5cm                 0.0235
+  17. soil_ksat_0_5cm                     0.0235
+  18. aspect                              0.0223
+  19. soil_clay_pct_5_15cm                0.0198
+  20. tri                                 0.0168
+  21. slope                               0.0162
+  22. elev_std_3x3                        0.0162
+  23. elev_5x5_std_dev                    0.0155
+  24. slope_5x5_std_dev                   0.0150
+  25. elev_5x5_rel                        0.0131
+  26. curvature_profile                   0.0095
+  27. curvature_plan                      0.0094
+  28. tpi_3x3                             0.0073
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  81,842
+  Estimated meadow area:        818.42 ha
+  Total valid pixels:           2,416,419
+  Meadow coverage:              3.39%
+
+PIPELINE RUNTIME
+  Total time: 10m 55s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Clear_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Clear_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Clear_Creek
+Date/Time: 2026-04-29 16:38:43
+================================================================================
+
+DATA SUMMARY
+  Total samples:           23,410
+  Wetland (1):             4,682  (20.0%)
+  Non-wetland (0):         18,728  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            17,557
+  Test set:                5,853
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9742
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0006
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9861
+  Accuracy:                0.9487
+
+  Wetland:
+    Precision:             0.8405
+    Recall:                0.9180
+    F1-score:              0.8776
+    Support:               1,171
+
+  Non-Wetland:
+    Precision:             0.9790
+    Recall:                0.9564
+    F1-score:              0.9676
+    Support:               4,682
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 4,478               204
+  Actual Wetland                  96             1,075
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.2039
+   2. dd_v                                0.1880
+   3. tpi_21x21                           0.1299
+   4. dd_s                                0.0309
+   5. dd_h                                0.0303
+   6. twi_10m                             0.0294
+   7. twi_100m                            0.0294
+   8. slope_std_9x9                       0.0292
+   9. aspect                              0.0271
+  10. tpi_11x11                           0.0245
+  11. curvature_profile                   0.0221
+  12. soil_organic_matter_0_5cm           0.0215
+  13. soil_clay_pct_0_5cm                 0.0201
+  14. soil_clay_pct_5_15cm                0.0189
+  15. soil_clay_pct_15_30cm               0.0171
+  16. slope                               0.0170
+  17. soil_ksat_0_5cm                     0.0165
+  18. slope_5x5_std_dev                   0.0162
+  19. soil_organic_matter_5_15cm          0.0160
+  20. soil_ksat_5_15cm                    0.0157
+  21. elev_5x5_std_dev                    0.0154
+  22. soil_ksat_15_30cm                   0.0150
+  23. soil_organic_matter_15_30cm         0.0126
+  24. elev_std_3x3                        0.0121
+  25. tri                                 0.0117
+  26. elev_5x5_rel                        0.0106
+  27. curvature_plan                      0.0101
+  28. tpi_3x3                             0.0088
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  127,652
+  Estimated meadow area:        1,276.52 ha
+  Total valid pixels:           2,892,864
+  Meadow coverage:              4.41%
+
+PIPELINE RUNTIME
+  Total time: 10m 55s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Clearwater_River_log.txt
+++ b/GEE/TIF_Output/Logs/Clearwater_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Clearwater_River
+Date/Time: 2026-04-29 16:38:16
+================================================================================
+
+DATA SUMMARY
+  Total samples:           40,850
+  Wetland (1):             8,170  (20.0%)
+  Non-wetland (0):         32,680  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            30,637
+  Test set:                10,213
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9868
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0003
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9961
+  Accuracy:                0.9761
+
+  Wetland:
+    Precision:             0.9190
+    Recall:                0.9657
+    F1-score:              0.9418
+    Support:               2,043
+
+  Non-Wetland:
+    Precision:             0.9913
+    Recall:                0.9787
+    F1-score:              0.9850
+    Support:               8,170
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 7,996               174
+  Actual Wetland                  70             1,973
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_5x5_std_dev                    0.3158
+   2. slope                               0.1317
+   3. tpi_21x21                           0.0710
+   4. soil_ksat_0_5cm                     0.0574
+   5. dd_v                                0.0542
+   6. soil_clay_pct_15_30cm               0.0337
+   7. soil_clay_pct_5_15cm                0.0269
+   8. soil_organic_matter_15_30cm         0.0267
+   9. dd_s                                0.0224
+  10. elev_std_9x9                        0.0220
+  11. twi_100m                            0.0213
+  12. soil_ksat_5_15cm                    0.0206
+  13. soil_organic_matter_5_15cm          0.0192
+  14. aspect                              0.0183
+  15. dd_h                                0.0180
+  16. soil_clay_pct_0_5cm                 0.0164
+  17. soil_ksat_15_30cm                   0.0163
+  18. elev_std_3x3                        0.0147
+  19. slope_std_9x9                       0.0140
+  20. twi_10m                             0.0133
+  21. soil_organic_matter_0_5cm           0.0117
+  22. curvature_plan                      0.0094
+  23. slope_5x5_std_dev                   0.0093
+  24. tpi_11x11                           0.0088
+  25. tri                                 0.0087
+  26. curvature_profile                   0.0076
+  27. elev_5x5_rel                        0.0070
+  28. tpi_3x3                             0.0036
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  51,204
+  Estimated meadow area:        512.04 ha
+  Total valid pixels:           1,999,548
+  Meadow coverage:              2.56%
+
+PIPELINE RUNTIME
+  Total time: 10m 30s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Coos_Bay_Frontal_Pacific_Ocean_log.txt
+++ b/GEE/TIF_Output/Logs/Coos_Bay_Frontal_Pacific_Ocean_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Coos_Bay_Frontal_Pacific_Ocean
+Date/Time: 2026-04-29 16:39:29
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9655
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9754
+  Accuracy:                0.9204
+
+  Wetland:
+    Precision:             0.7415
+    Recall:                0.9242
+    F1-score:              0.8228
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9798
+    Recall:                0.9194
+    F1-score:              0.9487
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                18,389             1,611
+  Actual Wetland                 379             4,621
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.2800
+   2. slope                               0.1233
+   3. tri                                 0.1191
+   4. soil_ksat_0_5cm                     0.0708
+   5. soil_clay_pct_15_30cm               0.0389
+   6. elev_std_3x3                        0.0389
+   7. tpi_21x21                           0.0301
+   8. soil_clay_pct_5_15cm                0.0300
+   9. soil_ksat_5_15cm                    0.0299
+  10. twi_100m                            0.0226
+  11. soil_organic_matter_15_30cm         0.0192
+  12. soil_organic_matter_0_5cm           0.0183
+  13. elev_5x5_std_dev                    0.0173
+  14. soil_clay_pct_0_5cm                 0.0150
+  15. soil_ksat_15_30cm                   0.0147
+  16. dd_s                                0.0146
+  17. curvature_plan                      0.0146
+  18. soil_organic_matter_5_15cm          0.0131
+  19. elev_std_9x9                        0.0117
+  20. dd_h                                0.0114
+  21. tpi_11x11                           0.0104
+  22. slope_std_9x9                       0.0093
+  23. aspect                              0.0089
+  24. twi_10m                             0.0086
+  25. slope_5x5_std_dev                   0.0084
+  26. elev_5x5_rel                        0.0076
+  27. curvature_profile                   0.0069
+  28. tpi_3x3                             0.0067
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  815,909
+  Estimated meadow area:        8,159.09 ha
+  Total valid pixels:           5,687,392
+  Meadow coverage:              14.35%
+
+PIPELINE RUNTIME
+  Total time: 11m 56s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Copco_Reservoir_Klamath_River_log.txt
+++ b/GEE/TIF_Output/Logs/Copco_Reservoir_Klamath_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Copco_Reservoir_Klamath_River
+Date/Time: 2026-04-29 16:39:01
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9756
+  colsample_bytree          0.8
+  gamma                     1.0
+  learning_rate             0.1
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.1
+  reg_lambda                1.5
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9928
+  Accuracy:                0.9650
+
+  Wetland:
+    Precision:             0.8760
+    Recall:                0.9608
+    F1-score:              0.9164
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9900
+    Recall:                0.9660
+    F1-score:              0.9778
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,320               680
+  Actual Wetland                 196             4,804
+
+FEATURE IMPORTANCES (ranked)
+   1. soil_clay_pct_5_15cm                0.3334
+   2. tpi_21x21                           0.1098
+   3. soil_clay_pct_15_30cm               0.0650
+   4. dd_v                                0.0381
+   5. twi_10m                             0.0292
+   6. dd_h                                0.0281
+   7. soil_organic_matter_5_15cm          0.0281
+   8. soil_ksat_0_5cm                     0.0277
+   9. dd_s                                0.0251
+  10. elev_std_9x9                        0.0239
+  11. aspect                              0.0233
+  12. elev_5x5_std_dev                    0.0228
+  13. soil_clay_pct_0_5cm                 0.0222
+  14. twi_100m                            0.0215
+  15. slope                               0.0206
+  16. tri                                 0.0200
+  17. soil_organic_matter_15_30cm         0.0181
+  18. tpi_11x11                           0.0175
+  19. soil_ksat_5_15cm                    0.0164
+  20. soil_organic_matter_0_5cm           0.0157
+  21. soil_ksat_15_30cm                   0.0155
+  22. curvature_plan                      0.0150
+  23. elev_std_3x3                        0.0137
+  24. slope_std_9x9                       0.0124
+  25. slope_5x5_std_dev                   0.0116
+  26. curvature_profile                   0.0101
+  27. elev_5x5_rel                        0.0093
+  28. tpi_3x3                             0.0060
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  132,296
+  Estimated meadow area:        1,322.96 ha
+  Total valid pixels:           3,503,918
+  Meadow coverage:              3.78%
+
+PIPELINE RUNTIME
+  Total time: 11m 17s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Coquille_River_log.txt
+++ b/GEE/TIF_Output/Logs/Coquille_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Coquille_River
+Date/Time: 2026-04-29 16:39:08
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9755
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9818
+  Accuracy:                0.9352
+
+  Wetland:
+    Precision:             0.7846
+    Recall:                0.9318
+    F1-score:              0.8519
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9821
+    Recall:                0.9361
+    F1-score:              0.9585
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                18,721             1,279
+  Actual Wetland                 341             4,659
+
+FEATURE IMPORTANCES (ranked)
+   1. soil_ksat_0_5cm                     0.3749
+   2. soil_ksat_5_15cm                    0.1234
+   3. elev_5x5_std_dev                    0.1108
+   4. tri                                 0.0720
+   5. elev_std_3x3                        0.0395
+   6. slope                               0.0382
+   7. elev_std_9x9                        0.0256
+   8. dd_v                                0.0227
+   9. soil_organic_matter_0_5cm           0.0197
+  10. tpi_21x21                           0.0179
+  11. soil_ksat_15_30cm                   0.0154
+  12. soil_organic_matter_15_30cm         0.0144
+  13. soil_clay_pct_0_5cm                 0.0111
+  14. dd_h                                0.0100
+  15. soil_clay_pct_5_15cm                0.0100
+  16. twi_100m                            0.0096
+  17. soil_clay_pct_15_30cm               0.0094
+  18. soil_organic_matter_5_15cm          0.0091
+  19. dd_s                                0.0088
+  20. tpi_11x11                           0.0073
+  21. slope_5x5_std_dev                   0.0069
+  22. slope_std_9x9                       0.0069
+  23. elev_5x5_rel                        0.0066
+  24. twi_10m                             0.0065
+  25. aspect                              0.0062
+  26. curvature_profile                   0.0062
+  27. curvature_plan                      0.0061
+  28. tpi_3x3                             0.0049
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  848,321
+  Estimated meadow area:        8,483.21 ha
+  Total valid pixels:           4,524,926
+  Meadow coverage:              18.75%
+
+PIPELINE RUNTIME
+  Total time: 11m 24s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Cottonwood_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Cottonwood_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Cottonwood_Creek
+Date/Time: 2026-04-29 16:38:59
+================================================================================
+
+DATA SUMMARY
+  Total samples:           31,185
+  Wetland (1):             6,237  (20.0%)
+  Non-wetland (0):         24,948  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            23,388
+  Test set:                7,797
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9761
+  colsample_bytree          1.0
+  gamma                     0.5
+  learning_rate             0.1
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                1.5
+  scale_pos_weight          3.9996
+  subsample                 0.6
+
+TEST SET PERFORMANCE
+  AUC:                     0.9884
+  Accuracy:                0.9536
+
+  Wetland:
+    Precision:             0.8403
+    Recall:                0.9480
+    F1-score:              0.8909
+    Support:               1,559
+
+  Non-Wetland:
+    Precision:             0.9866
+    Recall:                0.9550
+    F1-score:              0.9705
+    Support:               6,238
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 5,957               281
+  Actual Wetland                  81             1,478
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.2058
+   2. tpi_21x21                           0.1046
+   3. elev_std_9x9                        0.0749
+   4. slope                               0.0649
+   5. twi_10m                             0.0475
+   6. twi_100m                            0.0328
+   7. aspect                              0.0286
+   8. dd_h                                0.0282
+   9. dd_s                                0.0259
+  10. soil_ksat_0_5cm                     0.0239
+  11. soil_organic_matter_0_5cm           0.0238
+  12. soil_clay_pct_0_5cm                 0.0237
+  13. tpi_11x11                           0.0237
+  14. elev_5x5_std_dev                    0.0231
+  15. slope_5x5_std_dev                   0.0220
+  16. soil_organic_matter_5_15cm          0.0218
+  17. soil_ksat_15_30cm                   0.0214
+  18. soil_organic_matter_15_30cm         0.0211
+  19. soil_clay_pct_15_30cm               0.0209
+  20. slope_std_9x9                       0.0209
+  21. tri                                 0.0200
+  22. soil_clay_pct_5_15cm                0.0198
+  23. soil_ksat_5_15cm                    0.0184
+  24. elev_5x5_rel                        0.0179
+  25. curvature_plan                      0.0173
+  26. curvature_profile                   0.0171
+  27. elev_std_3x3                        0.0170
+  28. tpi_3x3                             0.0131
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  116,035
+  Estimated meadow area:        1,160.35 ha
+  Total valid pixels:           2,576,992
+  Meadow coverage:              4.50%
+
+PIPELINE RUNTIME
+  Total time: 11m 8s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Crater_Lake_Williamson_River_log.txt
+++ b/GEE/TIF_Output/Logs/Crater_Lake_Williamson_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Crater_Lake_Williamson_River
+Date/Time: 2026-04-29 16:39:10
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9942
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9968
+  Accuracy:                0.9757
+
+  Wetland:
+    Precision:             0.9131
+    Recall:                0.9708
+    F1-score:              0.9411
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9926
+    Recall:                0.9769
+    F1-score:              0.9847
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,538               462
+  Actual Wetland                 146             4,854
+
+FEATURE IMPORTANCES (ranked)
+   1. soil_clay_pct_0_5cm                 0.4439
+   2. soil_clay_pct_5_15cm                0.2420
+   3. soil_clay_pct_15_30cm               0.1024
+   4. soil_ksat_15_30cm                   0.0320
+   5. dd_v                                0.0183
+   6. soil_ksat_5_15cm                    0.0125
+   7. tri                                 0.0118
+   8. slope_5x5_std_dev                   0.0112
+   9. elev_5x5_std_dev                    0.0106
+  10. slope_std_9x9                       0.0097
+  11. elev_std_9x9                        0.0097
+  12. elev_std_3x3                        0.0096
+  13. slope                               0.0084
+  14. soil_ksat_0_5cm                     0.0082
+  15. twi_100m                            0.0080
+  16. soil_organic_matter_15_30cm         0.0074
+  17. soil_organic_matter_0_5cm           0.0070
+  18. aspect                              0.0063
+  19. tpi_21x21                           0.0062
+  20. dd_s                                0.0051
+  21. dd_h                                0.0050
+  22. soil_organic_matter_5_15cm          0.0048
+  23. curvature_plan                      0.0040
+  24. tpi_11x11                           0.0037
+  25. elev_5x5_rel                        0.0032
+  26. curvature_profile                   0.0031
+  27. twi_10m                             0.0030
+  28. tpi_3x3                             0.0028
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  922,285
+  Estimated meadow area:        9,222.85 ha
+  Total valid pixels:           4,268,302
+  Meadow coverage:              21.61%
+
+PIPELINE RUNTIME
+  Total time: 11m 28s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Crescent_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Crescent_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Crescent_Creek
+Date/Time: 2026-04-29 16:39:29
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9709
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9796
+  Accuracy:                0.9275
+
+  Wetland:
+    Precision:             0.7602
+    Recall:                0.9312
+    F1-score:              0.8370
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9818
+    Recall:                0.9265
+    F1-score:              0.9534
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                18,531             1,469
+  Actual Wetland                 344             4,656
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.2289
+   2. elev_5x5_std_dev                    0.2032
+   3. elev_std_3x3                        0.1099
+   4. tri                                 0.0608
+   5. dd_v                                0.0511
+   6. soil_clay_pct_0_5cm                 0.0345
+   7. tpi_21x21                           0.0250
+   8. slope                               0.0214
+   9. twi_100m                            0.0213
+  10. soil_clay_pct_5_15cm                0.0201
+  11. soil_ksat_15_30cm                   0.0192
+  12. slope_std_9x9                       0.0176
+  13. dd_h                                0.0168
+  14. soil_organic_matter_15_30cm         0.0162
+  15. soil_ksat_5_15cm                    0.0150
+  16. soil_clay_pct_15_30cm               0.0148
+  17. dd_s                                0.0144
+  18. soil_organic_matter_5_15cm          0.0132
+  19. slope_5x5_std_dev                   0.0125
+  20. soil_ksat_0_5cm                     0.0121
+  21. soil_organic_matter_0_5cm           0.0119
+  22. aspect                              0.0110
+  23. curvature_plan                      0.0101
+  24. tpi_11x11                           0.0096
+  25. twi_10m                             0.0090
+  26. elev_5x5_rel                        0.0075
+  27. curvature_profile                   0.0067
+  28. tpi_3x3                             0.0062
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  561,345
+  Estimated meadow area:        5,613.45 ha
+  Total valid pixels:           4,845,894
+  Meadow coverage:              11.58%
+
+PIPELINE RUNTIME
+  Total time: 11m 54s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Days_Creek_South_Umpqua_River_log.txt
+++ b/GEE/TIF_Output/Logs/Days_Creek_South_Umpqua_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Days_Creek_South_Umpqua_River
+Date/Time: 2026-04-29 16:39:01
+================================================================================
+
+DATA SUMMARY
+  Total samples:           91,520
+  Wetland (1):             18,304  (20.0%)
+  Non-wetland (0):         73,216  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            68,640
+  Test set:                22,880
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9778
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9879
+  Accuracy:                0.9439
+
+  Wetland:
+    Precision:             0.7995
+    Recall:                0.9604
+    F1-score:              0.8726
+    Support:               4,576
+
+  Non-Wetland:
+    Precision:             0.9896
+    Recall:                0.9398
+    F1-score:              0.9640
+    Support:               18,304
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                17,202             1,102
+  Actual Wetland                 181             4,395
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.3346
+   2. elev_std_9x9                        0.0854
+   3. elev_5x5_std_dev                    0.0758
+   4. tri                                 0.0737
+   5. slope_5x5_std_dev                   0.0523
+   6. tpi_21x21                           0.0410
+   7. slope_std_9x9                       0.0338
+   8. twi_100m                            0.0299
+   9. soil_ksat_15_30cm                   0.0219
+  10. dd_s                                0.0209
+  11. soil_clay_pct_15_30cm               0.0185
+  12. dd_h                                0.0184
+  13. soil_clay_pct_0_5cm                 0.0166
+  14. soil_organic_matter_15_30cm         0.0153
+  15. aspect                              0.0146
+  16. soil_organic_matter_0_5cm           0.0144
+  17. soil_clay_pct_5_15cm                0.0134
+  18. soil_organic_matter_5_15cm          0.0133
+  19. elev_std_3x3                        0.0127
+  20. soil_ksat_5_15cm                    0.0122
+  21. twi_10m                             0.0121
+  22. soil_ksat_0_5cm                     0.0116
+  23. curvature_plan                      0.0116
+  24. tpi_11x11                           0.0110
+  25. slope                               0.0098
+  26. elev_5x5_rel                        0.0097
+  27. curvature_profile                   0.0088
+  28. tpi_3x3                             0.0067
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  352,022
+  Estimated meadow area:        3,520.22 ha
+  Total valid pixels:           5,737,954
+  Meadow coverage:              6.13%
+
+PIPELINE RUNTIME
+  Total time: 11m 17s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Deer_Creek_South_Umpqua_River_log.txt
+++ b/GEE/TIF_Output/Logs/Deer_Creek_South_Umpqua_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Deer_Creek_South_Umpqua_River
+Date/Time: 2026-04-29 16:39:19
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9140
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9325
+  Accuracy:                0.8465
+
+  Wetland:
+    Precision:             0.5754
+    Recall:                0.8872
+    F1-score:              0.6980
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9674
+    Recall:                0.8363
+    F1-score:              0.8971
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                16,726             3,274
+  Actual Wetland                 564             4,436
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.1948
+   2. elev_5x5_std_dev                    0.1685
+   3. elev_std_3x3                        0.0906
+   4. soil_clay_pct_0_5cm                 0.0595
+   5. soil_clay_pct_15_30cm               0.0554
+   6. tpi_21x21                           0.0466
+   7. tri                                 0.0425
+   8. soil_clay_pct_5_15cm                0.0422
+   9. dd_v                                0.0247
+  10. slope                               0.0194
+  11. soil_ksat_15_30cm                   0.0179
+  12. soil_ksat_5_15cm                    0.0176
+  13. soil_organic_matter_0_5cm           0.0175
+  14. twi_100m                            0.0167
+  15. tpi_11x11                           0.0159
+  16. soil_organic_matter_15_30cm         0.0155
+  17. soil_organic_matter_5_15cm          0.0149
+  18. soil_ksat_0_5cm                     0.0149
+  19. aspect                              0.0146
+  20. dd_h                                0.0142
+  21. elev_5x5_rel                        0.0140
+  22. twi_10m                             0.0136
+  23. slope_std_9x9                       0.0128
+  24. dd_s                                0.0127
+  25. slope_5x5_std_dev                   0.0120
+  26. curvature_profile                   0.0111
+  27. tpi_3x3                             0.0102
+  28. curvature_plan                      0.0097
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  875,688
+  Estimated meadow area:        8,756.88 ha
+  Total valid pixels:           4,462,836
+  Meadow coverage:              19.62%
+
+PIPELINE RUNTIME
+  Total time: 11m 32s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Deer_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Deer_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Deer_Creek
+Date/Time: 2026-04-29 16:38:59
+================================================================================
+
+DATA SUMMARY
+  Total samples:           58,275
+  Wetland (1):             11,655  (20.0%)
+  Non-wetland (0):         46,620  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            43,706
+  Test set:                14,569
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9651
+  colsample_bytree          0.8
+  gamma                     1.0
+  learning_rate             0.1
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.1
+  reg_lambda                1.5
+  scale_pos_weight          4.0001
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9814
+  Accuracy:                0.9386
+
+  Wetland:
+    Precision:             0.8031
+    Recall:                0.9180
+    F1-score:              0.8567
+    Support:               2,914
+
+  Non-Wetland:
+    Precision:             0.9787
+    Recall:                0.9437
+    F1-score:              0.9609
+    Support:               11,655
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                10,999               656
+  Actual Wetland                 239             2,675
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.2257
+   2. tpi_21x21                           0.1314
+   3. soil_clay_pct_0_5cm                 0.0635
+   4. elev_5x5_std_dev                    0.0371
+   5. elev_std_9x9                        0.0337
+   6. slope                               0.0327
+   7. tpi_11x11                           0.0324
+   8. soil_ksat_0_5cm                     0.0296
+   9. twi_100m                            0.0293
+  10. soil_clay_pct_15_30cm               0.0252
+  11. aspect                              0.0247
+  12. soil_organic_matter_0_5cm           0.0245
+  13. soil_ksat_5_15cm                    0.0241
+  14. soil_clay_pct_5_15cm                0.0241
+  15. slope_5x5_std_dev                   0.0226
+  16. curvature_plan                      0.0225
+  17. soil_ksat_15_30cm                   0.0220
+  18. soil_organic_matter_15_30cm         0.0214
+  19. dd_s                                0.0213
+  20. soil_organic_matter_5_15cm          0.0211
+  21. dd_h                                0.0207
+  22. twi_10m                             0.0190
+  23. slope_std_9x9                       0.0186
+  24. tri                                 0.0180
+  25. elev_5x5_rel                        0.0169
+  26. elev_std_3x3                        0.0142
+  27. curvature_profile                   0.0127
+  28. tpi_3x3                             0.0109
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  171,190
+  Estimated meadow area:        1,711.90 ha
+  Total valid pixels:           2,943,574
+  Meadow coverage:              5.82%
+
+PIPELINE RUNTIME
+  Total time: 11m 9s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Diamond_Lake_log.txt
+++ b/GEE/TIF_Output/Logs/Diamond_Lake_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Diamond_Lake
+Date/Time: 2026-04-29 16:38:59
+================================================================================
+
+DATA SUMMARY
+  Total samples:           56,190
+  Wetland (1):             11,238  (20.0%)
+  Non-wetland (0):         44,952  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            42,142
+  Test set:                14,048
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9980
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0002
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9990
+  Accuracy:                0.9925
+
+  Wetland:
+    Precision:             0.9652
+    Recall:                0.9982
+    F1-score:              0.9815
+    Support:               2,810
+
+  Non-Wetland:
+    Precision:             0.9996
+    Recall:                0.9910
+    F1-score:              0.9953
+    Support:               11,238
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                11,137               101
+  Actual Wetland                   5             2,805
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.1625
+   2. elev_5x5_std_dev                    0.1538
+   3. soil_clay_pct_5_15cm                0.1156
+   4. soil_organic_matter_0_5cm           0.1090
+   5. tri                                 0.0623
+   6. twi_100m                            0.0411
+   7. elev_std_3x3                        0.0374
+   8. dd_v                                0.0370
+   9. soil_clay_pct_15_30cm               0.0363
+  10. slope_5x5_std_dev                   0.0352
+  11. dd_h                                0.0295
+  12. dd_s                                0.0287
+  13. slope_std_9x9                       0.0235
+  14. soil_clay_pct_0_5cm                 0.0180
+  15. soil_organic_matter_5_15cm          0.0162
+  16. tpi_21x21                           0.0133
+  17. slope                               0.0098
+  18. tpi_11x11                           0.0096
+  19. soil_ksat_15_30cm                   0.0093
+  20. soil_organic_matter_15_30cm         0.0084
+  21. soil_ksat_5_15cm                    0.0080
+  22. aspect                              0.0069
+  23. twi_10m                             0.0060
+  24. elev_5x5_rel                        0.0055
+  25. soil_ksat_0_5cm                     0.0053
+  26. curvature_profile                   0.0041
+  27. curvature_plan                      0.0040
+  28. tpi_3x3                             0.0037
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  28,182
+  Estimated meadow area:        281.82 ha
+  Total valid pixels:           1,740,518
+  Meadow coverage:              1.62%
+
+PIPELINE RUNTIME
+  Total time: 11m 6s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Dumont_Creek_South_Umpqua_River_log.txt
+++ b/GEE/TIF_Output/Logs/Dumont_Creek_South_Umpqua_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Dumont_Creek_South_Umpqua_River
+Date/Time: 2026-04-29 16:38:59
+================================================================================
+
+DATA SUMMARY
+  Total samples:           27,920
+  Wetland (1):             5,584  (20.0%)
+  Non-wetland (0):         22,336  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            20,940
+  Test set:                6,980
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9732
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9885
+  Accuracy:                0.9554
+
+  Wetland:
+    Precision:             0.8567
+    Recall:                0.9334
+    F1-score:              0.8934
+    Support:               1,396
+
+  Non-Wetland:
+    Precision:             0.9830
+    Recall:                0.9610
+    F1-score:              0.9718
+    Support:               5,584
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 5,366               218
+  Actual Wetland                  93             1,303
+
+FEATURE IMPORTANCES (ranked)
+   1. tpi_21x21                           0.2251
+   2. elev_std_9x9                        0.1166
+   3. twi_100m                            0.0897
+   4. slope                               0.0549
+   5. soil_organic_matter_15_30cm         0.0385
+   6. soil_organic_matter_0_5cm           0.0364
+   7. dd_v                                0.0338
+   8. slope_5x5_std_dev                   0.0274
+   9. tpi_11x11                           0.0258
+  10. soil_clay_pct_15_30cm               0.0258
+  11. soil_organic_matter_5_15cm          0.0253
+  12. dd_s                                0.0239
+  13. soil_ksat_5_15cm                    0.0224
+  14. dd_h                                0.0220
+  15. elev_std_3x3                        0.0214
+  16. aspect                              0.0213
+  17. soil_ksat_0_5cm                     0.0206
+  18. soil_clay_pct_0_5cm                 0.0199
+  19. slope_std_9x9                       0.0195
+  20. elev_5x5_std_dev                    0.0191
+  21. soil_ksat_15_30cm                   0.0182
+  22. twi_10m                             0.0166
+  23. soil_clay_pct_5_15cm                0.0160
+  24. curvature_profile                   0.0149
+  25. elev_5x5_rel                        0.0128
+  26. tri                                 0.0127
+  27. curvature_plan                      0.0101
+  28. tpi_3x3                             0.0092
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  160,361
+  Estimated meadow area:        1,603.61 ha
+  Total valid pixels:           4,009,139
+  Meadow coverage:              4.00%
+
+PIPELINE RUNTIME
+  Total time: 11m 10s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/East_Fork_Coquille_River_log.txt
+++ b/GEE/TIF_Output/Logs/East_Fork_Coquille_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: East_Fork_Coquille_River
+Date/Time: 2026-04-29 16:38:59
+================================================================================
+
+DATA SUMMARY
+  Total samples:           42,325
+  Wetland (1):             8,465  (20.0%)
+  Non-wetland (0):         33,860  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            31,743
+  Test set:                10,582
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9907
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          3.9997
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9964
+  Accuracy:                0.9785
+
+  Wetland:
+    Precision:             0.9094
+    Recall:                0.9910
+    F1-score:              0.9484
+    Support:               2,116
+
+  Non-Wetland:
+    Precision:             0.9977
+    Recall:                0.9753
+    F1-score:              0.9864
+    Support:               8,466
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 8,257               209
+  Actual Wetland                  19             2,097
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.5679
+   2. dd_v                                0.1075
+   3. dd_h                                0.0527
+   4. tri                                 0.0260
+   5. soil_ksat_5_15cm                    0.0241
+   6. slope_std_9x9                       0.0230
+   7. soil_organic_matter_15_30cm         0.0174
+   8. soil_ksat_0_5cm                     0.0158
+   9. soil_organic_matter_5_15cm          0.0148
+  10. tpi_21x21                           0.0147
+  11. soil_ksat_15_30cm                   0.0146
+  12. soil_clay_pct_0_5cm                 0.0133
+  13. soil_clay_pct_15_30cm               0.0120
+  14. twi_100m                            0.0107
+  15. soil_clay_pct_5_15cm                0.0101
+  16. dd_s                                0.0083
+  17. elev_5x5_std_dev                    0.0080
+  18. aspect                              0.0071
+  19. soil_organic_matter_0_5cm           0.0070
+  20. tpi_11x11                           0.0066
+  21. elev_std_3x3                        0.0065
+  22. slope_5x5_std_dev                   0.0064
+  23. elev_5x5_rel                        0.0049
+  24. curvature_plan                      0.0046
+  25. twi_10m                             0.0043
+  26. slope                               0.0041
+  27. curvature_profile                   0.0039
+  28. tpi_3x3                             0.0038
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  93,780
+  Estimated meadow area:        937.80 ha
+  Total valid pixels:           3,485,729
+  Meadow coverage:              2.69%
+
+PIPELINE RUNTIME
+  Total time: 11m 9s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/East_Fork_Illinois_River_log.txt
+++ b/GEE/TIF_Output/Logs/East_Fork_Illinois_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: East_Fork_Illinois_River
+Date/Time: 2026-04-29 16:38:59
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9668
+  colsample_bytree          0.8
+  gamma                     1.0
+  learning_rate             0.1
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.1
+  reg_lambda                1.5
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9851
+  Accuracy:                0.9454
+
+  Wetland:
+    Precision:             0.8143
+    Recall:                0.9418
+    F1-score:              0.8734
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9849
+    Recall:                0.9463
+    F1-score:              0.9652
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                18,926             1,074
+  Actual Wetland                 291             4,709
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.2899
+   2. elev_5x5_std_dev                    0.1792
+   3. soil_ksat_0_5cm                     0.0727
+   4. dd_v                                0.0368
+   5. twi_100m                            0.0305
+   6. tpi_21x21                           0.0303
+   7. soil_organic_matter_0_5cm           0.0269
+   8. slope_std_9x9                       0.0255
+   9. tri                                 0.0253
+  10. slope_5x5_std_dev                   0.0219
+  11. dd_h                                0.0207
+  12. soil_ksat_15_30cm                   0.0187
+  13. soil_clay_pct_5_15cm                0.0179
+  14. soil_organic_matter_5_15cm          0.0175
+  15. soil_organic_matter_15_30cm         0.0170
+  16. soil_clay_pct_15_30cm               0.0168
+  17. dd_s                                0.0166
+  18. soil_ksat_5_15cm                    0.0158
+  19. soil_clay_pct_0_5cm                 0.0154
+  20. aspect                              0.0153
+  21. curvature_plan                      0.0132
+  22. tpi_11x11                           0.0127
+  23. twi_10m                             0.0122
+  24. elev_std_3x3                        0.0119
+  25. slope                               0.0103
+  26. elev_5x5_rel                        0.0101
+  27. curvature_profile                   0.0095
+  28. tpi_3x3                             0.0095
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  150,547
+  Estimated meadow area:        1,505.47 ha
+  Total valid pixels:           2,344,397
+  Meadow coverage:              6.42%
+
+PIPELINE RUNTIME
+  Total time: 11m 8s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Elk_Creek_Rogue_log.txt
+++ b/GEE/TIF_Output/Logs/Elk_Creek_Rogue_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Elk_Creek_Rogue
+Date/Time: 2026-04-29 16:38:59
+================================================================================
+
+DATA SUMMARY
+  Total samples:           15,620
+  Wetland (1):             3,124  (20.0%)
+  Non-wetland (0):         12,496  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            11,715
+  Test set:                3,905
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9930
+  colsample_bytree          1.0
+  gamma                     0.5
+  learning_rate             0.1
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                1.5
+  scale_pos_weight          4.0
+  subsample                 0.6
+
+TEST SET PERFORMANCE
+  AUC:                     0.9953
+  Accuracy:                0.9734
+
+  Wetland:
+    Precision:             0.9035
+    Recall:                0.9706
+    F1-score:              0.9358
+    Support:               781
+
+  Non-Wetland:
+    Precision:             0.9925
+    Recall:                0.9741
+    F1-score:              0.9832
+    Support:               3,124
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 3,043                81
+  Actual Wetland                  23               758
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_5x5_std_dev                    0.4674
+   2. elev_std_9x9                        0.1077
+   3. tpi_21x21                           0.0636
+   4. tri                                 0.0245
+   5. twi_100m                            0.0224
+   6. aspect                              0.0219
+   7. dd_s                                0.0192
+   8. soil_organic_matter_5_15cm          0.0163
+   9. soil_ksat_5_15cm                    0.0158
+  10. dd_v                                0.0151
+  11. soil_ksat_15_30cm                   0.0149
+  12. curvature_plan                      0.0149
+  13. slope                               0.0142
+  14. twi_10m                             0.0141
+  15. slope_std_9x9                       0.0139
+  16. elev_5x5_rel                        0.0137
+  17. elev_std_3x3                        0.0135
+  18. tpi_11x11                           0.0135
+  19. slope_5x5_std_dev                   0.0131
+  20. soil_organic_matter_15_30cm         0.0124
+  21. dd_h                                0.0124
+  22. soil_organic_matter_0_5cm           0.0118
+  23. soil_clay_pct_0_5cm                 0.0118
+  24. soil_ksat_0_5cm                     0.0113
+  25. soil_clay_pct_5_15cm                0.0108
+  26. soil_clay_pct_15_30cm               0.0108
+  27. tpi_3x3                             0.0106
+  28. curvature_profile                   0.0085
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  101,180
+  Estimated meadow area:        1,011.80 ha
+  Total valid pixels:           3,464,513
+  Meadow coverage:              2.92%
+
+PIPELINE RUNTIME
+  Total time: 11m 9s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Elk_Creek_Umpqua_log.txt
+++ b/GEE/TIF_Output/Logs/Elk_Creek_Umpqua_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Elk_Creek_Umpqua
+Date/Time: 2026-04-29 16:38:59
+================================================================================
+
+DATA SUMMARY
+  Total samples:           17,870
+  Wetland (1):             3,574  (20.0%)
+  Non-wetland (0):         14,296  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            13,402
+  Test set:                4,468
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9797
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0007
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9881
+  Accuracy:                0.9557
+
+  Wetland:
+    Precision:             0.8558
+    Recall:                0.9362
+    F1-score:              0.8942
+    Support:               894
+
+  Non-Wetland:
+    Precision:             0.9837
+    Recall:                0.9605
+    F1-score:              0.9720
+    Support:               3,574
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 3,433               141
+  Actual Wetland                  57               837
+
+FEATURE IMPORTANCES (ranked)
+   1. tpi_21x21                           0.2194
+   2. dd_v                                0.1211
+   3. elev_std_9x9                        0.0857
+   4. slope                               0.0585
+   5. tri                                 0.0421
+   6. twi_100m                            0.0349
+   7. soil_organic_matter_0_5cm           0.0332
+   8. tpi_11x11                           0.0307
+   9. elev_std_3x3                        0.0282
+  10. soil_clay_pct_15_30cm               0.0271
+  11. elev_5x5_std_dev                    0.0255
+  12. dd_s                                0.0247
+  13. dd_h                                0.0223
+  14. slope_std_9x9                       0.0218
+  15. soil_clay_pct_0_5cm                 0.0213
+  16. aspect                              0.0212
+  17. soil_organic_matter_15_30cm         0.0188
+  18. soil_ksat_0_5cm                     0.0186
+  19. soil_organic_matter_5_15cm          0.0184
+  20. soil_ksat_15_30cm                   0.0183
+  21. slope_5x5_std_dev                   0.0182
+  22. soil_ksat_5_15cm                    0.0159
+  23. curvature_profile                   0.0156
+  24. twi_10m                             0.0153
+  25. soil_clay_pct_5_15cm                0.0150
+  26. curvature_plan                      0.0106
+  27. elev_5x5_rel                        0.0096
+  28. tpi_3x3                             0.0078
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  97,354
+  Estimated meadow area:        973.54 ha
+  Total valid pixels:           2,204,129
+  Meadow coverage:              4.42%
+
+PIPELINE RUNTIME
+  Total time: 11m 7s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Elk_River_log.txt
+++ b/GEE/TIF_Output/Logs/Elk_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Elk_River
+Date/Time: 2026-04-29 16:38:59
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9893
+  colsample_bytree          0.8
+  gamma                     0.5
+  learning_rate             0.1
+  max_depth                 6
+  min_child_weight          1
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9945
+  Accuracy:                0.9667
+
+  Wetland:
+    Precision:             0.8749
+    Recall:                0.9724
+    F1-score:              0.9211
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9929
+    Recall:                0.9653
+    F1-score:              0.9789
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,305               695
+  Actual Wetland                 138             4,862
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_5x5_std_dev                    0.5620
+   2. tri                                 0.1334
+   3. elev_std_9x9                        0.0508
+   4. curvature_plan                      0.0477
+   5. tpi_21x21                           0.0277
+   6. dd_v                                0.0204
+   7. soil_ksat_0_5cm                     0.0131
+   8. slope_5x5_std_dev                   0.0125
+   9. soil_clay_pct_15_30cm               0.0117
+  10. soil_ksat_5_15cm                    0.0115
+  11. twi_100m                            0.0111
+  12. tpi_11x11                           0.0082
+  13. slope_std_9x9                       0.0081
+  14. soil_clay_pct_5_15cm                0.0077
+  15. soil_organic_matter_5_15cm          0.0070
+  16. soil_clay_pct_0_5cm                 0.0070
+  17. dd_h                                0.0065
+  18. soil_ksat_15_30cm                   0.0060
+  19. elev_5x5_rel                        0.0059
+  20. soil_organic_matter_0_5cm           0.0059
+  21. elev_std_3x3                        0.0058
+  22. soil_organic_matter_15_30cm         0.0055
+  23. dd_s                                0.0047
+  24. twi_10m                             0.0044
+  25. curvature_profile                   0.0042
+  26. aspect                              0.0041
+  27. slope                               0.0040
+  28. tpi_3x3                             0.0030
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  105,268
+  Estimated meadow area:        1,052.68 ha
+  Total valid pixels:           2,364,456
+  Meadow coverage:              4.45%
+
+PIPELINE RUNTIME
+  Total time: 11m 8s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Euchre_Creek_Frontal_Pacific_Ocean_log.txt
+++ b/GEE/TIF_Output/Logs/Euchre_Creek_Frontal_Pacific_Ocean_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Euchre_Creek_Frontal_Pacific_Ocean
+Date/Time: 2026-04-29 16:39:05
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9785
+  colsample_bytree          1.0
+  gamma                     0.1
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              100
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                1
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9883
+  Accuracy:                0.9523
+
+  Wetland:
+    Precision:             0.8423
+    Recall:                0.9370
+    F1-score:              0.8871
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9838
+    Recall:                0.9562
+    F1-score:              0.9698
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,123               877
+  Actual Wetland                 315             4,685
+
+FEATURE IMPORTANCES (ranked)
+   1. tri                                 0.4993
+   2. elev_5x5_std_dev                    0.1450
+   3. dd_v                                0.0605
+   4. curvature_plan                      0.0424
+   5. tpi_21x21                           0.0165
+   6. soil_ksat_15_30cm                   0.0159
+   7. elev_std_9x9                        0.0157
+   8. soil_organic_matter_5_15cm          0.0147
+   9. soil_ksat_0_5cm                     0.0136
+  10. slope_5x5_std_dev                   0.0135
+  11. soil_clay_pct_15_30cm               0.0130
+  12. twi_100m                            0.0122
+  13. slope_std_9x9                       0.0119
+  14. soil_clay_pct_5_15cm                0.0116
+  15. soil_organic_matter_15_30cm         0.0111
+  16. soil_clay_pct_0_5cm                 0.0101
+  17. soil_organic_matter_0_5cm           0.0097
+  18. tpi_11x11                           0.0096
+  19. elev_std_3x3                        0.0088
+  20. dd_h                                0.0086
+  21. dd_s                                0.0086
+  22. soil_ksat_5_15cm                    0.0085
+  23. aspect                              0.0083
+  24. slope                               0.0069
+  25. elev_5x5_rel                        0.0067
+  26. twi_10m                             0.0061
+  27. tpi_3x3                             0.0058
+  28. curvature_profile                   0.0052
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  124,916
+  Estimated meadow area:        1,249.16 ha
+  Total valid pixels:           2,254,051
+  Meadow coverage:              5.54%
+
+PIPELINE RUNTIME
+  Total time: 11m 24s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Evans_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Evans_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Evans_Creek
+Date/Time: 2026-04-29 16:39:22
+================================================================================
+
+DATA SUMMARY
+  Total samples:           67,035
+  Wetland (1):             13,407  (20.0%)
+  Non-wetland (0):         53,628  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            50,276
+  Test set:                16,759
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9814
+  colsample_bytree          1.0
+  gamma                     0.1
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              100
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                1
+  scale_pos_weight          4.0001
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9930
+  Accuracy:                0.9658
+
+  Wetland:
+    Precision:             0.8744
+    Recall:                0.9681
+    F1-score:              0.9189
+    Support:               3,352
+
+  Non-Wetland:
+    Precision:             0.9918
+    Recall:                0.9652
+    F1-score:              0.9783
+    Support:               13,407
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                12,941               466
+  Actual Wetland                 107             3,245
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.4774
+   2. elev_std_9x9                        0.0519
+   3. tpi_21x21                           0.0412
+   4. twi_100m                            0.0402
+   5. curvature_plan                      0.0374
+   6. soil_ksat_0_5cm                     0.0303
+   7. soil_ksat_5_15cm                    0.0238
+   8. soil_organic_matter_5_15cm          0.0237
+   9. dd_s                                0.0213
+  10. elev_5x5_std_dev                    0.0209
+  11. soil_ksat_15_30cm                   0.0178
+  12. soil_organic_matter_0_5cm           0.0170
+  13. dd_h                                0.0158
+  14. tri                                 0.0158
+  15. slope_std_9x9                       0.0151
+  16. aspect                              0.0149
+  17. tpi_11x11                           0.0145
+  18. soil_organic_matter_15_30cm         0.0140
+  19. soil_clay_pct_15_30cm               0.0139
+  20. slope_5x5_std_dev                   0.0135
+  21. soil_clay_pct_0_5cm                 0.0125
+  22. soil_clay_pct_5_15cm                0.0115
+  23. twi_10m                             0.0113
+  24. slope                               0.0108
+  25. elev_std_3x3                        0.0105
+  26. curvature_profile                   0.0085
+  27. elev_5x5_rel                        0.0075
+  28. tpi_3x3                             0.0073
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  223,142
+  Estimated meadow area:        2,231.42 ha
+  Total valid pixels:           5,811,008
+  Meadow coverage:              3.84%
+
+PIPELINE RUNTIME
+  Total time: 11m 46s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Fish_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Fish_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Fish_Creek
+Date/Time: 2026-04-29 16:39:05
+================================================================================
+
+DATA SUMMARY
+  Total samples:           99,425
+  Wetland (1):             19,885  (20.0%)
+  Non-wetland (0):         79,540  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            74,568
+  Test set:                24,857
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9565
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          3.9999
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9913
+  Accuracy:                0.9636
+
+  Wetland:
+    Precision:             0.8796
+    Recall:                0.9479
+    F1-score:              0.9125
+    Support:               4,971
+
+  Non-Wetland:
+    Precision:             0.9867
+    Recall:                0.9676
+    F1-score:              0.9770
+    Support:               19,886
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,241               645
+  Actual Wetland                 259             4,712
+
+FEATURE IMPORTANCES (ranked)
+   1. tpi_21x21                           0.1709
+   2. elev_std_9x9                        0.0905
+   3. soil_ksat_15_30cm                   0.0855
+   4. dd_v                                0.0542
+   5. soil_clay_pct_0_5cm                 0.0478
+   6. aspect                              0.0470
+   7. dd_h                                0.0371
+   8. dd_s                                0.0368
+   9. elev_5x5_std_dev                    0.0356
+  10. twi_100m                            0.0320
+  11. soil_organic_matter_5_15cm          0.0301
+  12. soil_clay_pct_5_15cm                0.0293
+  13. twi_10m                             0.0278
+  14. soil_clay_pct_15_30cm               0.0255
+  15. soil_organic_matter_0_5cm           0.0250
+  16. elev_std_3x3                        0.0241
+  17. soil_ksat_5_15cm                    0.0239
+  18. slope_std_9x9                       0.0211
+  19. curvature_profile                   0.0208
+  20. soil_organic_matter_15_30cm         0.0200
+  21. soil_ksat_0_5cm                     0.0193
+  22. tri                                 0.0187
+  23. tpi_11x11                           0.0166
+  24. slope                               0.0161
+  25. slope_5x5_std_dev                   0.0134
+  26. curvature_plan                      0.0120
+  27. elev_5x5_rel                        0.0103
+  28. tpi_3x3                             0.0086
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  87,747
+  Estimated meadow area:        877.47 ha
+  Total valid pixels:           2,180,963
+  Meadow coverage:              4.02%
+
+PIPELINE RUNTIME
+  Total time: 11m 23s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Fourmile_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Fourmile_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Fourmile_Creek
+Date/Time: 2026-04-29 16:39:05
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9889
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9957
+  Accuracy:                0.9740
+
+  Wetland:
+    Precision:             0.9101
+    Recall:                0.9656
+    F1-score:              0.9370
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9913
+    Recall:                0.9761
+    F1-score:              0.9837
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,523               477
+  Actual Wetland                 172             4,828
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.6266
+   2. dd_v                                0.0522
+   3. soil_ksat_15_30cm                   0.0292
+   4. tpi_21x21                           0.0227
+   5. soil_organic_matter_0_5cm           0.0215
+   6. dd_h                                0.0210
+   7. soil_clay_pct_15_30cm               0.0174
+   8. soil_ksat_0_5cm                     0.0158
+   9. soil_ksat_5_15cm                    0.0154
+  10. dd_s                                0.0153
+  11. soil_clay_pct_5_15cm                0.0129
+  12. soil_clay_pct_0_5cm                 0.0129
+  13. soil_organic_matter_15_30cm         0.0126
+  14. aspect                              0.0123
+  15. twi_100m                            0.0116
+  16. curvature_plan                      0.0115
+  17. tri                                 0.0110
+  18. slope_std_9x9                       0.0095
+  19. tpi_11x11                           0.0093
+  20. slope_5x5_std_dev                   0.0083
+  21. twi_10m                             0.0079
+  22. soil_organic_matter_5_15cm          0.0078
+  23. slope                               0.0072
+  24. elev_5x5_std_dev                    0.0070
+  25. elev_std_3x3                        0.0065
+  26. elev_5x5_rel                        0.0057
+  27. curvature_profile                   0.0049
+  28. tpi_3x3                             0.0041
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  117,170
+  Estimated meadow area:        1,171.70 ha
+  Total valid pixels:           2,997,252
+  Meadow coverage:              3.91%
+
+PIPELINE RUNTIME
+  Total time: 11m 24s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Gold_Hill_Rogue_River_log.txt
+++ b/GEE/TIF_Output/Logs/Gold_Hill_Rogue_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Gold_Hill_Rogue_River
+Date/Time: 2026-04-29 16:39:25
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9472
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9652
+  Accuracy:                0.8878
+
+  Wetland:
+    Precision:             0.6515
+    Recall:                0.9442
+    F1-score:              0.7710
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9843
+    Recall:                0.8738
+    F1-score:              0.9257
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                17,475             2,525
+  Actual Wetland                 279             4,721
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.2316
+   2. elev_5x5_std_dev                    0.1824
+   3. dd_v                                0.0717
+   4. twi_100m                            0.0539
+   5. slope                               0.0444
+   6. soil_clay_pct_15_30cm               0.0370
+   7. tri                                 0.0311
+   8. soil_ksat_15_30cm                   0.0289
+   9. soil_organic_matter_15_30cm         0.0234
+  10. soil_clay_pct_5_15cm                0.0233
+  11. soil_ksat_5_15cm                    0.0218
+  12. tpi_21x21                           0.0209
+  13. soil_clay_pct_0_5cm                 0.0208
+  14. soil_ksat_0_5cm                     0.0196
+  15. soil_organic_matter_0_5cm           0.0181
+  16. elev_std_3x3                        0.0176
+  17. slope_5x5_std_dev                   0.0171
+  18. aspect                              0.0163
+  19. soil_organic_matter_5_15cm          0.0154
+  20. dd_h                                0.0141
+  21. slope_std_9x9                       0.0140
+  22. curvature_plan                      0.0140
+  23. tpi_11x11                           0.0135
+  24. dd_s                                0.0130
+  25. twi_10m                             0.0102
+  26. elev_5x5_rel                        0.0096
+  27. curvature_profile                   0.0081
+  28. tpi_3x3                             0.0080
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  752,614
+  Estimated meadow area:        7,526.14 ha
+  Total valid pixels:           5,514,402
+  Meadow coverage:              13.65%
+
+PIPELINE RUNTIME
+  Total time: 11m 52s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Grants_Pass_Rogue_River_log.txt
+++ b/GEE/TIF_Output/Logs/Grants_Pass_Rogue_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Grants_Pass_Rogue_River
+Date/Time: 2026-04-29 16:39:05
+================================================================================
+
+DATA SUMMARY
+  Total samples:           43,395
+  Wetland (1):             8,679  (20.0%)
+  Non-wetland (0):         34,716  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            32,546
+  Test set:                10,849
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9665
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0002
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9876
+  Accuracy:                0.9547
+
+  Wetland:
+    Precision:             0.8574
+    Recall:                0.9281
+    F1-score:              0.8913
+    Support:               2,170
+
+  Non-Wetland:
+    Precision:             0.9816
+    Recall:                0.9614
+    F1-score:              0.9714
+    Support:               8,679
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 8,344               335
+  Actual Wetland                 156             2,014
+
+FEATURE IMPORTANCES (ranked)
+   1. twi_100m                            0.1858
+   2. soil_ksat_0_5cm                     0.0849
+   3. elev_std_9x9                        0.0594
+   4. soil_clay_pct_15_30cm               0.0503
+   5. dd_v                                0.0496
+   6. soil_ksat_15_30cm                   0.0408
+   7. slope_std_9x9                       0.0405
+   8. dd_h                                0.0340
+   9. tpi_21x21                           0.0329
+  10. soil_clay_pct_0_5cm                 0.0326
+  11. soil_organic_matter_15_30cm         0.0322
+  12. slope                               0.0306
+  13. soil_organic_matter_0_5cm           0.0288
+  14. soil_organic_matter_5_15cm          0.0285
+  15. soil_ksat_5_15cm                    0.0279
+  16. soil_clay_pct_5_15cm                0.0263
+  17. slope_5x5_std_dev                   0.0242
+  18. elev_5x5_std_dev                    0.0241
+  19. dd_s                                0.0241
+  20. aspect                              0.0216
+  21. elev_std_3x3                        0.0210
+  22. tri                                 0.0194
+  23. curvature_plan                      0.0183
+  24. twi_10m                             0.0170
+  25. tpi_11x11                           0.0139
+  26. elev_5x5_rel                        0.0127
+  27. tpi_3x3                             0.0103
+  28. curvature_profile                   0.0086
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  95,909
+  Estimated meadow area:        959.09 ha
+  Total valid pixels:           2,182,136
+  Meadow coverage:              4.40%
+
+PIPELINE RUNTIME
+  Total time: 11m 23s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Grave_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Grave_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Grave_Creek
+Date/Time: 2026-04-29 16:39:05
+================================================================================
+
+DATA SUMMARY
+  Total samples:           24,335
+  Wetland (1):             4,867  (20.0%)
+  Non-wetland (0):         19,468  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            18,251
+  Test set:                6,084
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9932
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0003
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9968
+  Accuracy:                0.9740
+
+  Wetland:
+    Precision:             0.9008
+    Recall:                0.9778
+    F1-score:              0.9377
+    Support:               1,217
+
+  Non-Wetland:
+    Precision:             0.9943
+    Recall:                0.9731
+    F1-score:              0.9836
+    Support:               4,867
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 4,736               131
+  Actual Wetland                  27             1,190
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_5x5_std_dev                    0.2315
+   2. elev_std_9x9                        0.2082
+   3. elev_std_3x3                        0.1018
+   4. dd_v                                0.0632
+   5. tri                                 0.0559
+   6. twi_100m                            0.0525
+   7. slope_std_9x9                       0.0309
+   8. slope_5x5_std_dev                   0.0227
+   9. tpi_21x21                           0.0211
+  10. soil_clay_pct_5_15cm                0.0191
+  11. dd_s                                0.0169
+  12. dd_h                                0.0166
+  13. soil_clay_pct_15_30cm               0.0158
+  14. soil_organic_matter_15_30cm         0.0145
+  15. aspect                              0.0139
+  16. soil_clay_pct_0_5cm                 0.0129
+  17. soil_organic_matter_5_15cm          0.0125
+  18. soil_ksat_15_30cm                   0.0114
+  19. slope                               0.0114
+  20. soil_organic_matter_0_5cm           0.0092
+  21. soil_ksat_0_5cm                     0.0090
+  22. soil_ksat_5_15cm                    0.0085
+  23. curvature_plan                      0.0077
+  24. tpi_11x11                           0.0075
+  25. twi_10m                             0.0069
+  26. curvature_profile                   0.0066
+  27. elev_5x5_rel                        0.0061
+  28. tpi_3x3                             0.0057
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  129,967
+  Estimated meadow area:        1,299.67 ha
+  Total valid pixels:           4,239,086
+  Meadow coverage:              3.07%
+
+PIPELINE RUNTIME
+  Total time: 11m 26s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Headwaters_Applegate_River_log.txt
+++ b/GEE/TIF_Output/Logs/Headwaters_Applegate_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Headwaters_Applegate_River
+Date/Time: 2026-04-29 16:39:44
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9507
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9815
+  Accuracy:                0.9410
+
+  Wetland:
+    Precision:             0.8199
+    Recall:                0.9034
+    F1-score:              0.8596
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9752
+    Recall:                0.9504
+    F1-score:              0.9626
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,008               992
+  Actual Wetland                 483             4,517
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.1732
+   2. tpi_21x21                           0.1256
+   3. dd_h                                0.0640
+   4. soil_organic_matter_15_30cm         0.0479
+   5. aspect                              0.0426
+   6. twi_10m                             0.0392
+   7. dd_s                                0.0371
+   8. soil_clay_pct_0_5cm                 0.0366
+   9. twi_100m                            0.0362
+  10. dd_v                                0.0348
+  11. soil_ksat_15_30cm                   0.0345
+  12. soil_clay_pct_15_30cm               0.0317
+  13. soil_clay_pct_5_15cm                0.0313
+  14. slope_std_9x9                       0.0294
+  15. tri                                 0.0274
+  16. elev_5x5_std_dev                    0.0262
+  17. slope_5x5_std_dev                   0.0232
+  18. soil_organic_matter_5_15cm          0.0214
+  19. soil_ksat_5_15cm                    0.0192
+  20. soil_ksat_0_5cm                     0.0171
+  21. soil_organic_matter_0_5cm           0.0151
+  22. elev_std_3x3                        0.0145
+  23. tpi_11x11                           0.0143
+  24. curvature_plan                      0.0132
+  25. elev_5x5_rel                        0.0120
+  26. slope                               0.0118
+  27. curvature_profile                   0.0110
+  28. tpi_3x3                             0.0098
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  313,618
+  Estimated meadow area:        3,136.18 ha
+  Total valid pixels:           5,765,142
+  Meadow coverage:              5.44%
+
+PIPELINE RUNTIME
+  Total time: 12m 3s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Headwaters_North_Umpqua_River_log.txt
+++ b/GEE/TIF_Output/Logs/Headwaters_North_Umpqua_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Headwaters_North_Umpqua_River
+Date/Time: 2026-04-29 16:39:10
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9846
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9975
+  Accuracy:                0.9825
+
+  Wetland:
+    Precision:             0.9367
+    Recall:                0.9788
+    F1-score:              0.9573
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9946
+    Recall:                0.9835
+    F1-score:              0.9890
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,669               331
+  Actual Wetland                 106             4,894
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_5x5_std_dev                    0.4422
+   2. tpi_21x21                           0.0815
+   3. elev_std_9x9                        0.0547
+   4. dd_s                                0.0405
+   5. dd_v                                0.0365
+   6. soil_ksat_5_15cm                    0.0352
+   7. dd_h                                0.0321
+   8. soil_clay_pct_0_5cm                 0.0250
+   9. twi_100m                            0.0203
+  10. soil_organic_matter_5_15cm          0.0197
+  11. soil_ksat_15_30cm                   0.0174
+  12. soil_organic_matter_15_30cm         0.0172
+  13. soil_ksat_0_5cm                     0.0166
+  14. elev_std_3x3                        0.0165
+  15. soil_organic_matter_0_5cm           0.0161
+  16. aspect                              0.0158
+  17. slope_std_9x9                       0.0140
+  18. soil_clay_pct_15_30cm               0.0133
+  19. twi_10m                             0.0128
+  20. curvature_plan                      0.0120
+  21. soil_clay_pct_5_15cm                0.0118
+  22. slope_5x5_std_dev                   0.0091
+  23. tri                                 0.0076
+  24. tpi_11x11                           0.0075
+  25. slope                               0.0070
+  26. elev_5x5_rel                        0.0070
+  27. curvature_profile                   0.0063
+  28. tpi_3x3                             0.0045
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  72,085
+  Estimated meadow area:        720.85 ha
+  Total valid pixels:           3,109,807
+  Meadow coverage:              2.32%
+
+PIPELINE RUNTIME
+  Total time: 11m 26s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Headwaters_Rogue_River_log.txt
+++ b/GEE/TIF_Output/Logs/Headwaters_Rogue_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Headwaters_Rogue_River
+Date/Time: 2026-04-29 16:39:59
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9210
+  colsample_bytree          0.8
+  gamma                     1.0
+  learning_rate             0.1
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.1
+  reg_lambda                1.5
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9618
+  Accuracy:                0.9079
+
+  Wetland:
+    Precision:             0.7242
+    Recall:                0.8716
+    F1-score:              0.7911
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9662
+    Recall:                0.9170
+    F1-score:              0.9409
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                18,340             1,660
+  Actual Wetland                 642             4,358
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.1657
+   2. tpi_21x21                           0.1025
+   3. soil_clay_pct_5_15cm                0.0627
+   4. elev_5x5_std_dev                    0.0460
+   5. tri                                 0.0402
+   6. soil_organic_matter_5_15cm          0.0349
+   7. twi_100m                            0.0344
+   8. soil_clay_pct_15_30cm               0.0342
+   9. slope                               0.0322
+  10. soil_ksat_15_30cm                   0.0321
+  11. soil_organic_matter_15_30cm         0.0294
+  12. dd_s                                0.0287
+  13. tpi_11x11                           0.0284
+  14. elev_std_9x9                        0.0280
+  15. soil_ksat_5_15cm                    0.0274
+  16. dd_h                                0.0263
+  17. aspect                              0.0259
+  18. soil_ksat_0_5cm                     0.0258
+  19. soil_clay_pct_0_5cm                 0.0257
+  20. soil_organic_matter_0_5cm           0.0241
+  21. twi_10m                             0.0236
+  22. slope_std_9x9                       0.0234
+  23. slope_5x5_std_dev                   0.0193
+  24. elev_std_3x3                        0.0184
+  25. elev_5x5_rel                        0.0171
+  26. curvature_plan                      0.0165
+  27. curvature_profile                   0.0139
+  28. tpi_3x3                             0.0133
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  876,646
+  Estimated meadow area:        8,766.46 ha
+  Total valid pixels:           10,069,048
+  Meadow coverage:              8.71%
+
+PIPELINE RUNTIME
+  Total time: 12m 31s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Hellgate_Canyon_Rogue_River_log.txt
+++ b/GEE/TIF_Output/Logs/Hellgate_Canyon_Rogue_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Hellgate_Canyon_Rogue_River
+Date/Time: 2026-04-29 16:39:05
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9872
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9913
+  Accuracy:                0.9592
+
+  Wetland:
+    Precision:             0.8457
+    Recall:                0.9734
+    F1-score:              0.9051
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9931
+    Recall:                0.9556
+    F1-score:              0.9740
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,112               888
+  Actual Wetland                 133             4,867
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.2270
+   2. elev_5x5_std_dev                    0.1745
+   3. dd_v                                0.1687
+   4. tri                                 0.1054
+   5. soil_ksat_0_5cm                     0.0330
+   6. twi_100m                            0.0270
+   7. slope_5x5_std_dev                   0.0207
+   8. slope_std_9x9                       0.0206
+   9. tpi_21x21                           0.0205
+  10. elev_std_3x3                        0.0205
+  11. soil_organic_matter_0_5cm           0.0161
+  12. soil_ksat_15_30cm                   0.0145
+  13. slope                               0.0139
+  14. aspect                              0.0128
+  15. soil_organic_matter_15_30cm         0.0122
+  16. soil_ksat_5_15cm                    0.0121
+  17. soil_organic_matter_5_15cm          0.0116
+  18. soil_clay_pct_0_5cm                 0.0115
+  19. dd_s                                0.0108
+  20. dd_h                                0.0098
+  21. soil_clay_pct_5_15cm                0.0088
+  22. soil_clay_pct_15_30cm               0.0082
+  23. tpi_11x11                           0.0079
+  24. curvature_plan                      0.0075
+  25. twi_10m                             0.0068
+  26. curvature_profile                   0.0066
+  27. elev_5x5_rel                        0.0058
+  28. tpi_3x3                             0.0049
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  189,382
+  Estimated meadow area:        1,893.82 ha
+  Total valid pixels:           3,785,325
+  Meadow coverage:              5.00%
+
+PIPELINE RUNTIME
+  Total time: 11m 24s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Hog_Creek_Williamson_River_log.txt
+++ b/GEE/TIF_Output/Logs/Hog_Creek_Williamson_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Hog_Creek_Williamson_River
+Date/Time: 2026-04-29 16:39:44
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9777
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9843
+  Accuracy:                0.9357
+
+  Wetland:
+    Precision:             0.7887
+    Recall:                0.9270
+    F1-score:              0.8523
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9809
+    Recall:                0.9379
+    F1-score:              0.9589
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                18,758             1,242
+  Actual Wetland                 365             4,635
+
+FEATURE IMPORTANCES (ranked)
+   1. tri                                 0.3267
+   2. dd_v                                0.0924
+   3. slope                               0.0746
+   4. elev_5x5_std_dev                    0.0620
+   5. elev_std_3x3                        0.0478
+   6. twi_100m                            0.0410
+   7. soil_clay_pct_5_15cm                0.0328
+   8. soil_clay_pct_0_5cm                 0.0304
+   9. soil_organic_matter_15_30cm         0.0292
+  10. elev_std_9x9                        0.0269
+  11. soil_ksat_0_5cm                     0.0216
+  12. soil_ksat_15_30cm                   0.0206
+  13. soil_ksat_5_15cm                    0.0198
+  14. soil_organic_matter_5_15cm          0.0194
+  15. tpi_21x21                           0.0171
+  16. curvature_plan                      0.0159
+  17. soil_clay_pct_15_30cm               0.0155
+  18. soil_organic_matter_0_5cm           0.0152
+  19. slope_5x5_std_dev                   0.0146
+  20. dd_s                                0.0127
+  21. slope_std_9x9                       0.0119
+  22. dd_h                                0.0119
+  23. aspect                              0.0077
+  24. tpi_11x11                           0.0076
+  25. curvature_profile                   0.0065
+  26. elev_5x5_rel                        0.0064
+  27. twi_10m                             0.0061
+  28. tpi_3x3                             0.0057
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  661,459
+  Estimated meadow area:        6,614.59 ha
+  Total valid pixels:           5,845,392
+  Meadow coverage:              11.32%
+
+PIPELINE RUNTIME
+  Total time: 12m 3s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Horse_Creek_Klamath_River_log.txt
+++ b/GEE/TIF_Output/Logs/Horse_Creek_Klamath_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Horse_Creek_Klamath_River
+Date/Time: 2026-04-29 16:39:22
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9259
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9496
+  Accuracy:                0.8780
+
+  Wetland:
+    Precision:             0.6397
+    Recall:                0.8930
+    F1-score:              0.7454
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9703
+    Recall:                0.8742
+    F1-score:              0.9198
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                17,485             2,515
+  Actual Wetland                 535             4,465
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.1727
+   2. tpi_21x21                           0.1157
+   3. elev_std_9x9                        0.0721
+   4. elev_5x5_std_dev                    0.0674
+   5. twi_100m                            0.0473
+   6. twi_10m                             0.0430
+   7. elev_std_3x3                        0.0319
+   8. dd_s                                0.0303
+   9. slope_std_9x9                       0.0278
+  10. aspect                              0.0276
+  11. tri                                 0.0261
+  12. slope_5x5_std_dev                   0.0254
+  13. dd_h                                0.0253
+  14. soil_organic_matter_15_30cm         0.0242
+  15. tpi_11x11                           0.0242
+  16. soil_clay_pct_15_30cm               0.0220
+  17. soil_ksat_5_15cm                    0.0209
+  18. slope                               0.0197
+  19. soil_clay_pct_0_5cm                 0.0195
+  20. soil_organic_matter_0_5cm           0.0190
+  21. soil_clay_pct_5_15cm                0.0188
+  22. soil_ksat_0_5cm                     0.0187
+  23. soil_ksat_15_30cm                   0.0187
+  24. curvature_profile                   0.0176
+  25. elev_5x5_rel                        0.0175
+  26. curvature_plan                      0.0170
+  27. soil_organic_matter_5_15cm          0.0164
+  28. tpi_3x3                             0.0133
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  524,013
+  Estimated meadow area:        5,240.13 ha
+  Total valid pixels:           3,999,581
+  Meadow coverage:              13.10%
+
+PIPELINE RUNTIME
+  Total time: 11m 45s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Horseshoe_Bend_Rogue_River_log.txt
+++ b/GEE/TIF_Output/Logs/Horseshoe_Bend_Rogue_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Horseshoe_Bend_Rogue_River
+Date/Time: 2026-04-29 16:39:05
+================================================================================
+
+DATA SUMMARY
+  Total samples:           13,420
+  Wetland (1):             2,684  (20.0%)
+  Non-wetland (0):         10,736  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            10,065
+  Test set:                3,355
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9940
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9939
+  Accuracy:                0.9717
+
+  Wetland:
+    Precision:             0.9248
+    Recall:                0.9344
+    F1-score:              0.9296
+    Support:               671
+
+  Non-Wetland:
+    Precision:             0.9836
+    Recall:                0.9810
+    F1-score:              0.9823
+    Support:               2,684
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 2,633                51
+  Actual Wetland                  44               627
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.3320
+   2. elev_5x5_std_dev                    0.1967
+   3. elev_std_9x9                        0.0737
+   4. slope_std_9x9                       0.0553
+   5. tpi_21x21                           0.0377
+   6. soil_organic_matter_5_15cm          0.0258
+   7. twi_100m                            0.0208
+   8. slope_5x5_std_dev                   0.0186
+   9. dd_h                                0.0182
+  10. soil_clay_pct_15_30cm               0.0174
+  11. soil_organic_matter_15_30cm         0.0161
+  12. soil_organic_matter_0_5cm           0.0158
+  13. aspect                              0.0146
+  14. soil_clay_pct_0_5cm                 0.0142
+  15. soil_ksat_5_15cm                    0.0139
+  16. soil_clay_pct_5_15cm                0.0137
+  17. tri                                 0.0127
+  18. soil_ksat_0_5cm                     0.0123
+  19. elev_5x5_rel                        0.0111
+  20. tpi_11x11                           0.0107
+  21. twi_10m                             0.0107
+  22. slope                               0.0104
+  23. soil_ksat_15_30cm                   0.0103
+  24. dd_s                                0.0094
+  25. elev_std_3x3                        0.0092
+  26. curvature_profile                   0.0073
+  27. curvature_plan                      0.0059
+  28. tpi_3x3                             0.0055
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  99,541
+  Estimated meadow area:        995.41 ha
+  Total valid pixels:           4,220,807
+  Meadow coverage:              2.36%
+
+PIPELINE RUNTIME
+  Total time: 11m 25s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Humbug_Creek_Klamath_River_log.txt
+++ b/GEE/TIF_Output/Logs/Humbug_Creek_Klamath_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Humbug_Creek_Klamath_River
+Date/Time: 2026-04-29 16:39:10
+================================================================================
+
+DATA SUMMARY
+  Total samples:           25,745
+  Wetland (1):             5,149  (20.0%)
+  Non-wetland (0):         20,596  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            19,308
+  Test set:                6,437
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9753
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          3.9995
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9889
+  Accuracy:                0.9563
+
+  Wetland:
+    Precision:             0.8677
+    Recall:                0.9223
+    F1-score:              0.8942
+    Support:               1,287
+
+  Non-Wetland:
+    Precision:             0.9803
+    Recall:                0.9649
+    F1-score:              0.9725
+    Support:               5,150
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 4,969               181
+  Actual Wetland                 100             1,187
+
+FEATURE IMPORTANCES (ranked)
+   1. tpi_21x21                           0.2753
+   2. elev_std_3x3                        0.1103
+   3. elev_std_9x9                        0.0719
+   4. elev_5x5_std_dev                    0.0477
+   5. dd_h                                0.0455
+   6. dd_v                                0.0357
+   7. dd_s                                0.0332
+   8. twi_100m                            0.0265
+   9. aspect                              0.0256
+  10. slope                               0.0243
+  11. slope_std_9x9                       0.0229
+  12. soil_organic_matter_15_30cm         0.0202
+  13. soil_organic_matter_0_5cm           0.0202
+  14. tpi_11x11                           0.0200
+  15. twi_10m                             0.0183
+  16. soil_clay_pct_5_15cm                0.0182
+  17. soil_clay_pct_15_30cm               0.0176
+  18. slope_5x5_std_dev                   0.0175
+  19. soil_ksat_15_30cm                   0.0172
+  20. soil_ksat_0_5cm                     0.0168
+  21. elev_5x5_rel                        0.0164
+  22. soil_organic_matter_5_15cm          0.0164
+  23. soil_clay_pct_0_5cm                 0.0158
+  24. tpi_3x3                             0.0142
+  25. curvature_profile                   0.0135
+  26. tri                                 0.0131
+  27. curvature_plan                      0.0130
+  28. soil_ksat_5_15cm                    0.0125
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  101,922
+  Estimated meadow area:        1,019.22 ha
+  Total valid pixels:           2,759,543
+  Meadow coverage:              3.69%
+
+PIPELINE RUNTIME
+  Total time: 11m 26s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Hunter_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Hunter_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Hunter_Creek
+Date/Time: 2026-04-29 16:39:05
+================================================================================
+
+DATA SUMMARY
+  Total samples:           17,160
+  Wetland (1):             3,432  (20.0%)
+  Non-wetland (0):         13,728  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            12,870
+  Test set:                4,290
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9866
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9912
+  Accuracy:                0.9615
+
+  Wetland:
+    Precision:             0.8854
+    Recall:                0.9277
+    F1-score:              0.9061
+    Support:               858
+
+  Non-Wetland:
+    Precision:             0.9817
+    Recall:                0.9700
+    F1-score:              0.9758
+    Support:               3,432
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 3,329               103
+  Actual Wetland                  62               796
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.3097
+   2. elev_5x5_std_dev                    0.1357
+   3. tpi_21x21                           0.1167
+   4. elev_std_9x9                        0.0868
+   5. slope_5x5_std_dev                   0.0350
+   6. tri                                 0.0202
+   7. dd_h                                0.0193
+   8. twi_100m                            0.0190
+   9. elev_5x5_rel                        0.0190
+  10. slope_std_9x9                       0.0188
+  11. aspect                              0.0173
+  12. soil_clay_pct_15_30cm               0.0155
+  13. soil_clay_pct_0_5cm                 0.0154
+  14. soil_organic_matter_0_5cm           0.0147
+  15. soil_ksat_5_15cm                    0.0145
+  16. soil_organic_matter_5_15cm          0.0139
+  17. soil_organic_matter_15_30cm         0.0135
+  18. dd_s                                0.0125
+  19. tpi_11x11                           0.0123
+  20. elev_std_3x3                        0.0116
+  21. soil_ksat_15_30cm                   0.0115
+  22. curvature_profile                   0.0107
+  23. curvature_plan                      0.0105
+  24. twi_10m                             0.0102
+  25. soil_ksat_0_5cm                     0.0099
+  26. tpi_3x3                             0.0097
+  27. soil_clay_pct_5_15cm                0.0084
+  28. slope                               0.0079
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  41,773
+  Estimated meadow area:        417.73 ha
+  Total valid pixels:           1,154,808
+  Meadow coverage:              3.62%
+
+PIPELINE RUNTIME
+  Total time: 11m 20s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Indian_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Indian_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Indian_Creek
+Date/Time: 2026-04-29 16:39:01
+================================================================================
+
+DATA SUMMARY
+  Total samples:           56,440
+  Wetland (1):             11,288  (20.0%)
+  Non-wetland (0):         45,152  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            42,330
+  Test set:                14,110
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9709
+  colsample_bytree          1.0
+  gamma                     0.5
+  learning_rate             0.1
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                1.5
+  scale_pos_weight          4.0
+  subsample                 0.6
+
+TEST SET PERFORMANCE
+  AUC:                     0.9867
+  Accuracy:                0.9499
+
+  Wetland:
+    Precision:             0.8439
+    Recall:                0.9196
+    F1-score:              0.8801
+    Support:               2,822
+
+  Non-Wetland:
+    Precision:             0.9794
+    Recall:                0.9575
+    F1-score:              0.9683
+    Support:               11,288
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                10,808               480
+  Actual Wetland                 227             2,595
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.3204
+   2. elev_std_9x9                        0.0755
+   3. tpi_21x21                           0.0702
+   4. soil_ksat_15_30cm                   0.0397
+   5. soil_clay_pct_15_30cm               0.0305
+   6. aspect                              0.0299
+   7. soil_clay_pct_0_5cm                 0.0296
+   8. dd_h                                0.0291
+   9. twi_100m                            0.0264
+  10. slope_std_9x9                       0.0252
+  11. elev_5x5_std_dev                    0.0247
+  12. dd_s                                0.0240
+  13. twi_10m                             0.0236
+  14. soil_ksat_5_15cm                    0.0222
+  15. soil_organic_matter_0_5cm           0.0210
+  16. soil_organic_matter_15_30cm         0.0200
+  17. tpi_11x11                           0.0190
+  18. soil_clay_pct_5_15cm                0.0185
+  19. soil_organic_matter_5_15cm          0.0175
+  20. soil_ksat_0_5cm                     0.0173
+  21. curvature_profile                   0.0171
+  22. slope                               0.0160
+  23. slope_5x5_std_dev                   0.0153
+  24. tri                                 0.0148
+  25. curvature_plan                      0.0146
+  26. elev_5x5_rel                        0.0135
+  27. elev_std_3x3                        0.0126
+  28. tpi_3x3                             0.0118
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  153,670
+  Estimated meadow area:        1,536.70 ha
+  Total valid pixels:           3,496,493
+  Meadow coverage:              4.39%
+
+PIPELINE RUNTIME
+  Total time: 11m 16s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Indigo_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Indigo_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Indigo_Creek
+Date/Time: 2026-04-29 16:38:49
+================================================================================
+
+DATA SUMMARY
+  Total samples:           6,225
+  Wetland (1):             1,245  (20.0%)
+  Non-wetland (0):         4,980  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            4,668
+  Test set:                1,557
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9951
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          3.9979
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9968
+  Accuracy:                0.9801
+
+  Wetland:
+    Precision:             0.9348
+    Recall:                0.9678
+    F1-score:              0.9510
+    Support:               311
+
+  Non-Wetland:
+    Precision:             0.9919
+    Recall:                0.9831
+    F1-score:              0.9875
+    Support:               1,246
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 1,225                21
+  Actual Wetland                  10               301
+
+FEATURE IMPORTANCES (ranked)
+   1. tpi_21x21                           0.2304
+   2. soil_organic_matter_15_30cm         0.1200
+   3. slope_5x5_std_dev                   0.0649
+   4. elev_5x5_std_dev                    0.0519
+   5. soil_clay_pct_15_30cm               0.0516
+   6. soil_clay_pct_5_15cm                0.0477
+   7. elev_std_3x3                        0.0435
+   8. tri                                 0.0403
+   9. dd_v                                0.0395
+  10. elev_std_9x9                        0.0309
+  11. soil_ksat_15_30cm                   0.0302
+  12. soil_clay_pct_0_5cm                 0.0251
+  13. soil_organic_matter_0_5cm           0.0246
+  14. twi_100m                            0.0244
+  15. slope_std_9x9                       0.0228
+  16. twi_10m                             0.0208
+  17. aspect                              0.0151
+  18. tpi_3x3                             0.0138
+  19. curvature_plan                      0.0128
+  20. dd_s                                0.0127
+  21. soil_organic_matter_5_15cm          0.0127
+  22. dd_h                                0.0113
+  23. soil_ksat_0_5cm                     0.0109
+  24. tpi_11x11                           0.0105
+  25. soil_ksat_5_15cm                    0.0096
+  26. slope                               0.0089
+  27. elev_5x5_rel                        0.0080
+  28. curvature_profile                   0.0051
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  47,297
+  Estimated meadow area:        472.97 ha
+  Total valid pixels:           1,986,305
+  Meadow coverage:              2.38%
+
+PIPELINE RUNTIME
+  Total time: 11m 1s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Iron_Gate_Reservoir_Klamath_River_log.txt
+++ b/GEE/TIF_Output/Logs/Iron_Gate_Reservoir_Klamath_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Iron_Gate_Reservoir_Klamath_River
+Date/Time: 2026-04-29 16:38:49
+================================================================================
+
+DATA SUMMARY
+  Total samples:           14,330
+  Wetland (1):             2,866  (20.0%)
+  Non-wetland (0):         11,464  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            10,747
+  Test set:                3,583
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9854
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0009
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9910
+  Accuracy:                0.9587
+
+  Wetland:
+    Precision:             0.8671
+    Recall:                0.9372
+    F1-score:              0.9008
+    Support:               717
+
+  Non-Wetland:
+    Precision:             0.9840
+    Recall:                0.9641
+    F1-score:              0.9739
+    Support:               2,866
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 2,763               103
+  Actual Wetland                  45               672
+
+FEATURE IMPORTANCES (ranked)
+   1. tpi_21x21                           0.1582
+   2. elev_5x5_std_dev                    0.0936
+   3. soil_ksat_5_15cm                    0.0564
+   4. soil_ksat_0_5cm                     0.0518
+   5. dd_v                                0.0461
+   6. soil_clay_pct_0_5cm                 0.0418
+   7. slope_5x5_std_dev                   0.0397
+   8. elev_std_9x9                        0.0384
+   9. soil_ksat_15_30cm                   0.0372
+  10. dd_s                                0.0369
+  11. twi_100m                            0.0339
+  12. soil_clay_pct_5_15cm                0.0304
+  13. soil_organic_matter_5_15cm          0.0299
+  14. aspect                              0.0285
+  15. slope                               0.0278
+  16. soil_organic_matter_0_5cm           0.0266
+  17. soil_clay_pct_15_30cm               0.0256
+  18. twi_10m                             0.0244
+  19. soil_organic_matter_15_30cm         0.0244
+  20. tpi_11x11                           0.0241
+  21. tri                                 0.0227
+  22. slope_std_9x9                       0.0216
+  23. dd_h                                0.0192
+  24. elev_5x5_rel                        0.0150
+  25. curvature_profile                   0.0124
+  26. elev_std_3x3                        0.0119
+  27. tpi_3x3                             0.0113
+  28. curvature_plan                      0.0105
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  59,325
+  Estimated meadow area:        593.25 ha
+  Total valid pixels:           1,716,297
+  Meadow coverage:              3.46%
+
+PIPELINE RUNTIME
+  Total time: 11m 2s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Jack_Creek_Williamson_River_log.txt
+++ b/GEE/TIF_Output/Logs/Jack_Creek_Williamson_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Jack_Creek_Williamson_River
+Date/Time: 2026-04-29 16:40:16
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9842
+  colsample_bytree          0.8
+  gamma                     0.1
+  learning_rate             0.05
+  max_depth                 6
+  min_child_weight          5
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                1.5
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9904
+  Accuracy:                0.9568
+
+  Wetland:
+    Precision:             0.8675
+    Recall:                0.9254
+    F1-score:              0.8955
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9810
+    Recall:                0.9647
+    F1-score:              0.9728
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,293               707
+  Actual Wetland                 373             4,627
+
+FEATURE IMPORTANCES (ranked)
+   1. soil_clay_pct_15_30cm               0.5563
+   2. soil_clay_pct_5_15cm                0.1272
+   3. twi_100m                            0.0484
+   4. elev_5x5_std_dev                    0.0255
+   5. tpi_21x21                           0.0229
+   6. elev_std_9x9                        0.0202
+   7. dd_h                                0.0194
+   8. dd_v                                0.0154
+   9. dd_s                                0.0141
+  10. slope                               0.0120
+  11. curvature_plan                      0.0116
+  12. elev_std_3x3                        0.0112
+  13. soil_ksat_15_30cm                   0.0108
+  14. soil_ksat_0_5cm                     0.0106
+  15. tri                                 0.0100
+  16. soil_ksat_5_15cm                    0.0083
+  17. tpi_11x11                           0.0080
+  18. soil_clay_pct_0_5cm                 0.0079
+  19. slope_5x5_std_dev                   0.0078
+  20. slope_std_9x9                       0.0076
+  21. soil_organic_matter_5_15cm          0.0074
+  22. soil_organic_matter_15_30cm         0.0062
+  23. aspect                              0.0058
+  24. soil_organic_matter_0_5cm           0.0058
+  25. elev_5x5_rel                        0.0055
+  26. curvature_profile                   0.0051
+  27. twi_10m                             0.0046
+  28. tpi_3x3                             0.0044
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  1,728,097
+  Estimated meadow area:        17,280.97 ha
+  Total valid pixels:           9,556,264
+  Meadow coverage:              18.08%
+
+PIPELINE RUNTIME
+  Total time: 12m 42s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Jackson_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Jackson_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Jackson_Creek
+Date/Time: 2026-04-29 16:38:49
+================================================================================
+
+DATA SUMMARY
+  Total samples:           42,030
+  Wetland (1):             8,406  (20.0%)
+  Non-wetland (0):         33,624  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            31,522
+  Test set:                10,508
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9830
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0003
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9936
+  Accuracy:                0.9701
+
+  Wetland:
+    Precision:             0.9060
+    Recall:                0.9491
+    F1-score:              0.9270
+    Support:               2,102
+
+  Non-Wetland:
+    Precision:             0.9871
+    Recall:                0.9754
+    F1-score:              0.9812
+    Support:               8,406
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 8,199               207
+  Actual Wetland                 107             1,995
+
+FEATURE IMPORTANCES (ranked)
+   1. tpi_21x21                           0.1466
+   2. slope                               0.1275
+   3. twi_10m                             0.1171
+   4. soil_clay_pct_0_5cm                 0.0787
+   5. aspect                              0.0440
+   6. dd_v                                0.0407
+   7. elev_5x5_std_dev                    0.0380
+   8. soil_clay_pct_15_30cm               0.0367
+   9. elev_std_9x9                        0.0352
+  10. soil_clay_pct_5_15cm                0.0298
+  11. soil_ksat_15_30cm                   0.0238
+  12. twi_100m                            0.0232
+  13. tri                                 0.0226
+  14. dd_s                                0.0226
+  15. slope_std_9x9                       0.0223
+  16. dd_h                                0.0210
+  17. soil_ksat_5_15cm                    0.0210
+  18. soil_ksat_0_5cm                     0.0188
+  19. soil_organic_matter_5_15cm          0.0176
+  20. soil_organic_matter_15_30cm         0.0166
+  21. tpi_11x11                           0.0152
+  22. elev_std_3x3                        0.0140
+  23. soil_organic_matter_0_5cm           0.0138
+  24. slope_5x5_std_dev                   0.0122
+  25. curvature_plan                      0.0114
+  26. elev_5x5_rel                        0.0102
+  27. curvature_profile                   0.0100
+  28. tpi_3x3                             0.0093
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  111,213
+  Estimated meadow area:        1,112.13 ha
+  Total valid pixels:           4,153,105
+  Meadow coverage:              2.68%
+
+PIPELINE RUNTIME
+  Total time: 11m 6s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Jenny_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Jenny_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Jenny_Creek
+Date/Time: 2026-04-29 16:39:01
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9708
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9852
+  Accuracy:                0.9418
+
+  Wetland:
+    Precision:             0.8054
+    Recall:                0.9348
+    F1-score:              0.8653
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9830
+    Recall:                0.9435
+    F1-score:              0.9629
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                18,871             1,129
+  Actual Wetland                 326             4,674
+
+FEATURE IMPORTANCES (ranked)
+   1. soil_clay_pct_5_15cm                0.4053
+   2. soil_clay_pct_15_30cm               0.1445
+   3. soil_clay_pct_0_5cm                 0.0487
+   4. tpi_21x21                           0.0473
+   5. dd_v                                0.0379
+   6. soil_ksat_5_15cm                    0.0275
+   7. elev_5x5_std_dev                    0.0243
+   8. soil_ksat_0_5cm                     0.0207
+   9. tri                                 0.0189
+  10. elev_std_3x3                        0.0165
+  11. soil_organic_matter_15_30cm         0.0160
+  12. elev_std_9x9                        0.0156
+  13. dd_h                                0.0143
+  14. soil_ksat_15_30cm                   0.0143
+  15. soil_organic_matter_5_15cm          0.0136
+  16. slope                               0.0132
+  17. soil_organic_matter_0_5cm           0.0130
+  18. tpi_11x11                           0.0130
+  19. twi_100m                            0.0126
+  20. curvature_plan                      0.0115
+  21. dd_s                                0.0114
+  22. twi_10m                             0.0104
+  23. slope_std_9x9                       0.0101
+  24. slope_5x5_std_dev                   0.0097
+  25. aspect                              0.0096
+  26. elev_5x5_rel                        0.0074
+  27. curvature_profile                   0.0068
+  28. tpi_3x3                             0.0059
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  357,999
+  Estimated meadow area:        3,579.99 ha
+  Total valid pixels:           5,448,853
+  Meadow coverage:              6.57%
+
+PIPELINE RUNTIME
+  Total time: 11m 18s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/John_C_Boyle_Reservoir_Klamath_River_log.txt
+++ b/GEE/TIF_Output/Logs/John_C_Boyle_Reservoir_Klamath_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: John_C_Boyle_Reservoir_Klamath_River
+Date/Time: 2026-04-29 16:38:57
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9874
+  colsample_bytree          1.0
+  gamma                     0.1
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              100
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                1
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9948
+  Accuracy:                0.9704
+
+  Wetland:
+    Precision:             0.8946
+    Recall:                0.9660
+    F1-score:              0.9289
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9913
+    Recall:                0.9716
+    F1-score:              0.9813
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,431               569
+  Actual Wetland                 170             4,830
+
+FEATURE IMPORTANCES (ranked)
+   1. tri                                 0.4358
+   2. dd_v                                0.1184
+   3. soil_ksat_0_5cm                     0.0939
+   4. soil_ksat_5_15cm                    0.0558
+   5. elev_5x5_std_dev                    0.0435
+   6. tpi_21x21                           0.0325
+   7. slope_std_9x9                       0.0156
+   8. twi_100m                            0.0150
+   9. elev_std_9x9                        0.0137
+  10. soil_organic_matter_5_15cm          0.0130
+  11. soil_clay_pct_0_5cm                 0.0128
+  12. soil_clay_pct_15_30cm               0.0125
+  13. soil_ksat_15_30cm                   0.0124
+  14. soil_organic_matter_15_30cm         0.0118
+  15. elev_std_3x3                        0.0115
+  16. soil_organic_matter_0_5cm           0.0113
+  17. aspect                              0.0111
+  18. slope_5x5_std_dev                   0.0107
+  19. slope                               0.0085
+  20. twi_10m                             0.0084
+  21. curvature_plan                      0.0079
+  22. soil_clay_pct_5_15cm                0.0079
+  23. dd_s                                0.0076
+  24. tpi_11x11                           0.0063
+  25. dd_h                                0.0062
+  26. elev_5x5_rel                        0.0059
+  27. curvature_profile                   0.0057
+  28. tpi_3x3                             0.0045
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  133,793
+  Estimated meadow area:        1,337.93 ha
+  Total valid pixels:           4,069,433
+  Meadow coverage:              3.29%
+
+PIPELINE RUNTIME
+  Total time: 11m 8s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Josephine_Creek_Illinois_River_log.txt
+++ b/GEE/TIF_Output/Logs/Josephine_Creek_Illinois_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Josephine_Creek_Illinois_River
+Date/Time: 2026-04-29 16:38:49
+================================================================================
+
+DATA SUMMARY
+  Total samples:           28,015
+  Wetland (1):             5,603  (20.0%)
+  Non-wetland (0):         22,412  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            21,011
+  Test set:                7,004
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9937
+  colsample_bytree          0.8
+  gamma                     1.0
+  learning_rate             0.1
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.1
+  reg_lambda                1.5
+  scale_pos_weight          4.0002
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9974
+  Accuracy:                0.9816
+
+  Wetland:
+    Precision:             0.9332
+    Recall:                0.9779
+    F1-score:              0.9550
+    Support:               1,401
+
+  Non-Wetland:
+    Precision:             0.9944
+    Recall:                0.9825
+    F1-score:              0.9884
+    Support:               5,603
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 5,505                98
+  Actual Wetland                  31             1,370
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.3259
+   2. elev_5x5_std_dev                    0.2311
+   3. slope_std_9x9                       0.0380
+   4. tpi_21x21                           0.0365
+   5. soil_organic_matter_0_5cm           0.0339
+   6. dd_v                                0.0310
+   7. soil_ksat_0_5cm                     0.0307
+   8. soil_clay_pct_0_5cm                 0.0251
+   9. slope                               0.0249
+  10. slope_5x5_std_dev                   0.0224
+  11. soil_organic_matter_5_15cm          0.0196
+  12. soil_organic_matter_15_30cm         0.0179
+  13. twi_100m                            0.0167
+  14. dd_h                                0.0161
+  15. dd_s                                0.0135
+  16. soil_ksat_15_30cm                   0.0124
+  17. tpi_11x11                           0.0120
+  18. tri                                 0.0119
+  19. soil_ksat_5_15cm                    0.0114
+  20. soil_clay_pct_5_15cm                0.0100
+  21. soil_clay_pct_15_30cm               0.0088
+  22. aspect                              0.0086
+  23. twi_10m                             0.0084
+  24. curvature_plan                      0.0078
+  25. elev_std_3x3                        0.0076
+  26. elev_5x5_rel                        0.0064
+  27. tpi_3x3                             0.0058
+  28. curvature_profile                   0.0056
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  76,673
+  Estimated meadow area:        766.73 ha
+  Total valid pixels:           3,314,265
+  Meadow coverage:              2.31%
+
+PIPELINE RUNTIME
+  Total time: 11m 2s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Jumpoff_Joe_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Jumpoff_Joe_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Jumpoff_Joe_Creek
+Date/Time: 2026-04-29 16:38:49
+================================================================================
+
+DATA SUMMARY
+  Total samples:           25,575
+  Wetland (1):             5,115  (20.0%)
+  Non-wetland (0):         20,460  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            19,181
+  Test set:                6,394
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9871
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0003
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9944
+  Accuracy:                0.9692
+
+  Wetland:
+    Precision:             0.8990
+    Recall:                0.9531
+    F1-score:              0.9252
+    Support:               1,279
+
+  Non-Wetland:
+    Precision:             0.9881
+    Recall:                0.9732
+    F1-score:              0.9806
+    Support:               5,115
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 4,978               137
+  Actual Wetland                  60             1,219
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.2673
+   2. elev_5x5_std_dev                    0.0958
+   3. dd_v                                0.0639
+   4. soil_clay_pct_15_30cm               0.0605
+   5. curvature_plan                      0.0460
+   6. tpi_21x21                           0.0401
+   7. soil_ksat_15_30cm                   0.0397
+   8. soil_ksat_5_15cm                    0.0375
+   9. soil_clay_pct_5_15cm                0.0328
+  10. twi_100m                            0.0323
+  11. slope_std_9x9                       0.0270
+  12. tri                                 0.0253
+  13. soil_organic_matter_0_5cm           0.0236
+  14. slope_5x5_std_dev                   0.0235
+  15. soil_organic_matter_5_15cm          0.0198
+  16. soil_ksat_0_5cm                     0.0195
+  17. aspect                              0.0193
+  18. soil_clay_pct_0_5cm                 0.0190
+  19. soil_organic_matter_15_30cm         0.0188
+  20. dd_s                                0.0166
+  21. tpi_11x11                           0.0136
+  22. twi_10m                             0.0102
+  23. slope                               0.0093
+  24. elev_std_3x3                        0.0093
+  25. dd_h                                0.0092
+  26. elev_5x5_rel                        0.0077
+  27. tpi_3x3                             0.0066
+  28. curvature_profile                   0.0057
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  89,359
+  Estimated meadow area:        893.59 ha
+  Total valid pixels:           2,827,392
+  Meadow coverage:              3.16%
+
+PIPELINE RUNTIME
+  Total time: 11m 3s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Klondike_Creek_Illinois_River_log.txt
+++ b/GEE/TIF_Output/Logs/Klondike_Creek_Illinois_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Klondike_Creek_Illinois_River
+Date/Time: 2026-04-29 16:38:49
+================================================================================
+
+DATA SUMMARY
+  Total samples:           5,405
+  Wetland (1):             1,081  (20.0%)
+  Non-wetland (0):         4,324  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            4,053
+  Test set:                1,352
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9961
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.05
+  max_depth                 6
+  min_child_weight          1
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.1
+  reg_lambda                1.5
+  scale_pos_weight          3.9975
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9946
+  Accuracy:                0.9689
+
+  Wetland:
+    Precision:             0.8800
+    Recall:                0.9778
+    F1-score:              0.9263
+    Support:               270
+
+  Non-Wetland:
+    Precision:             0.9943
+    Recall:                0.9667
+    F1-score:              0.9803
+    Support:               1,082
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 1,046                36
+  Actual Wetland                   6               264
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.4848
+   2. slope                               0.1383
+   3. slope_5x5_std_dev                   0.0520
+   4. tpi_21x21                           0.0494
+   5. twi_100m                            0.0210
+   6. soil_organic_matter_0_5cm           0.0203
+   7. soil_ksat_5_15cm                    0.0194
+   8. tpi_11x11                           0.0190
+   9. elev_std_9x9                        0.0172
+  10. slope_std_9x9                       0.0171
+  11. dd_h                                0.0171
+  12. soil_ksat_0_5cm                     0.0131
+  13. aspect                              0.0129
+  14. soil_organic_matter_5_15cm          0.0125
+  15. curvature_plan                      0.0123
+  16. dd_s                                0.0121
+  17. soil_organic_matter_15_30cm         0.0105
+  18. twi_10m                             0.0101
+  19. soil_clay_pct_15_30cm               0.0098
+  20. elev_5x5_std_dev                    0.0096
+  21. tri                                 0.0080
+  22. soil_clay_pct_0_5cm                 0.0066
+  23. soil_ksat_15_30cm                   0.0066
+  24. elev_5x5_rel                        0.0056
+  25. soil_clay_pct_5_15cm                0.0046
+  26. tpi_3x3                             0.0034
+  27. curvature_profile                   0.0034
+  28. elev_std_3x3                        0.0034
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  71,870
+  Estimated meadow area:        718.70 ha
+  Total valid pixels:           2,721,741
+  Meadow coverage:              2.64%
+
+PIPELINE RUNTIME
+  Total time: 11m 3s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Lake_Ewauna_Klamath_River_log.txt
+++ b/GEE/TIF_Output/Logs/Lake_Ewauna_Klamath_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Lake_Ewauna_Klamath_River
+Date/Time: 2026-04-29 16:39:22
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9345
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9519
+  Accuracy:                0.8735
+
+  Wetland:
+    Precision:             0.6285
+    Recall:                0.8990
+    F1-score:              0.7398
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9717
+    Recall:                0.8671
+    F1-score:              0.9165
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                17,343             2,657
+  Actual Wetland                 505             4,495
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.2281
+   2. soil_ksat_0_5cm                     0.0648
+   3. twi_100m                            0.0645
+   4. soil_clay_pct_0_5cm                 0.0617
+   5. elev_std_9x9                        0.0493
+   6. soil_organic_matter_5_15cm          0.0486
+   7. soil_organic_matter_15_30cm         0.0429
+   8. elev_5x5_std_dev                    0.0409
+   9. slope                               0.0373
+  10. slope_5x5_std_dev                   0.0317
+  11. soil_ksat_5_15cm                    0.0295
+  12. soil_clay_pct_5_15cm                0.0287
+  13. soil_organic_matter_0_5cm           0.0264
+  14. tpi_21x21                           0.0236
+  15. slope_std_9x9                       0.0232
+  16. soil_ksat_15_30cm                   0.0220
+  17. soil_clay_pct_15_30cm               0.0201
+  18. dd_h                                0.0185
+  19. aspect                              0.0178
+  20. tri                                 0.0173
+  21. dd_s                                0.0170
+  22. elev_std_3x3                        0.0167
+  23. curvature_plan                      0.0128
+  24. twi_10m                             0.0128
+  25. tpi_11x11                           0.0127
+  26. tpi_3x3                             0.0113
+  27. elev_5x5_rel                        0.0112
+  28. curvature_profile                   0.0084
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  573,790
+  Estimated meadow area:        5,737.90 ha
+  Total valid pixels:           3,156,194
+  Meadow coverage:              18.18%
+
+PIPELINE RUNTIME
+  Total time: 11m 46s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Lawson_Creek_Illinois_River_log.txt
+++ b/GEE/TIF_Output/Logs/Lawson_Creek_Illinois_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Lawson_Creek_Illinois_River
+Date/Time: 2026-04-29 16:38:49
+================================================================================
+
+DATA SUMMARY
+  Total samples:           11,300
+  Wetland (1):             2,260  (20.0%)
+  Non-wetland (0):         9,040  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            8,475
+  Test set:                2,825
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9914
+  colsample_bytree          1.0
+  gamma                     0.5
+  learning_rate             0.1
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                1.5
+  scale_pos_weight          4.0
+  subsample                 0.6
+
+TEST SET PERFORMANCE
+  AUC:                     0.9903
+  Accuracy:                0.9554
+
+  Wetland:
+    Precision:             0.8479
+    Recall:                0.9469
+    F1-score:              0.8946
+    Support:               565
+
+  Non-Wetland:
+    Precision:             0.9863
+    Recall:                0.9575
+    F1-score:              0.9717
+    Support:               2,260
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 2,164                96
+  Actual Wetland                  30               535
+
+FEATURE IMPORTANCES (ranked)
+   1. tri                                 0.3418
+   2. dd_v                                0.0977
+   3. tpi_21x21                           0.0923
+   4. slope_5x5_std_dev                   0.0387
+   5. elev_std_9x9                        0.0381
+   6. curvature_plan                      0.0365
+   7. elev_5x5_std_dev                    0.0242
+   8. twi_100m                            0.0237
+   9. slope_std_9x9                       0.0234
+  10. soil_organic_matter_0_5cm           0.0221
+  11. soil_organic_matter_5_15cm          0.0206
+  12. soil_clay_pct_0_5cm                 0.0193
+  13. tpi_11x11                           0.0186
+  14. dd_s                                0.0167
+  15. aspect                              0.0166
+  16. slope                               0.0163
+  17. soil_organic_matter_15_30cm         0.0162
+  18. elev_std_3x3                        0.0160
+  19. soil_ksat_15_30cm                   0.0141
+  20. soil_clay_pct_5_15cm                0.0139
+  21. soil_ksat_5_15cm                    0.0130
+  22. tpi_3x3                             0.0129
+  23. soil_clay_pct_15_30cm               0.0125
+  24. soil_ksat_0_5cm                     0.0119
+  25. twi_10m                             0.0119
+  26. curvature_profile                   0.0113
+  27. dd_h                                0.0104
+  28. elev_5x5_rel                        0.0091
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  62,290
+  Estimated meadow area:        622.90 ha
+  Total valid pixels:           1,670,832
+  Meadow coverage:              3.73%
+
+PIPELINE RUNTIME
+  Total time: 11m 1s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Little_Applegate_River_log.txt
+++ b/GEE/TIF_Output/Logs/Little_Applegate_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Little_Applegate_River
+Date/Time: 2026-04-29 16:38:57
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9543
+  colsample_bytree          0.8
+  gamma                     1.0
+  learning_rate             0.1
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                1
+  scale_pos_weight          4.0
+  subsample                 0.6
+
+TEST SET PERFORMANCE
+  AUC:                     0.9816
+  Accuracy:                0.9386
+
+  Wetland:
+    Precision:             0.7985
+    Recall:                0.9272
+    F1-score:              0.8580
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9810
+    Recall:                0.9415
+    F1-score:              0.9609
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                18,830             1,170
+  Actual Wetland                 364             4,636
+
+FEATURE IMPORTANCES (ranked)
+   1. soil_clay_pct_0_5cm                 0.1836
+   2. tpi_21x21                           0.1004
+   3. elev_std_9x9                        0.0785
+   4. dd_v                                0.0610
+   5. elev_5x5_std_dev                    0.0529
+   6. twi_10m                             0.0381
+   7. soil_organic_matter_15_30cm         0.0374
+   8. tpi_11x11                           0.0316
+   9. soil_organic_matter_0_5cm           0.0273
+  10. slope                               0.0271
+  11. twi_100m                            0.0257
+  12. soil_organic_matter_5_15cm          0.0254
+  13. soil_clay_pct_15_30cm               0.0251
+  14. aspect                              0.0243
+  15. dd_s                                0.0231
+  16. soil_clay_pct_5_15cm                0.0225
+  17. slope_std_9x9                       0.0213
+  18. soil_ksat_15_30cm                   0.0206
+  19. soil_ksat_0_5cm                     0.0203
+  20. dd_h                                0.0196
+  21. soil_ksat_5_15cm                    0.0196
+  22. curvature_plan                      0.0181
+  23. slope_5x5_std_dev                   0.0180
+  24. elev_5x5_rel                        0.0178
+  25. tri                                 0.0162
+  26. elev_std_3x3                        0.0154
+  27. tpi_3x3                             0.0146
+  28. curvature_profile                   0.0145
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  190,688
+  Estimated meadow area:        1,906.88 ha
+  Total valid pixels:           2,931,052
+  Meadow coverage:              6.51%
+
+PIPELINE RUNTIME
+  Total time: 11m 8s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Little_Butte_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Little_Butte_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Little_Butte_Creek
+Date/Time: 2026-04-29 16:39:26
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9733
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9824
+  Accuracy:                0.9333
+
+  Wetland:
+    Precision:             0.7807
+    Recall:                0.9270
+    F1-score:              0.8476
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9809
+    Recall:                0.9349
+    F1-score:              0.9573
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                18,698             1,302
+  Actual Wetland                 365             4,635
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.2385
+   2. elev_5x5_std_dev                    0.1904
+   3. slope                               0.0627
+   4. dd_v                                0.0580
+   5. elev_std_3x3                        0.0515
+   6. tri                                 0.0489
+   7. tpi_21x21                           0.0388
+   8. soil_ksat_0_5cm                     0.0322
+   9. soil_organic_matter_0_5cm           0.0220
+  10. twi_100m                            0.0202
+  11. dd_h                                0.0198
+  12. soil_organic_matter_5_15cm          0.0186
+  13. soil_ksat_5_15cm                    0.0186
+  14. soil_clay_pct_5_15cm                0.0176
+  15. soil_clay_pct_15_30cm               0.0168
+  16. soil_clay_pct_0_5cm                 0.0161
+  17. dd_s                                0.0156
+  18. soil_organic_matter_15_30cm         0.0154
+  19. soil_ksat_15_30cm                   0.0133
+  20. slope_5x5_std_dev                   0.0133
+  21. slope_std_9x9                       0.0109
+  22. curvature_plan                      0.0106
+  23. aspect                              0.0104
+  24. twi_10m                             0.0095
+  25. tpi_11x11                           0.0093
+  26. elev_5x5_rel                        0.0075
+  27. curvature_profile                   0.0071
+  28. tpi_3x3                             0.0064
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  724,207
+  Estimated meadow area:        7,242.07 ha
+  Total valid pixels:           9,678,512
+  Meadow coverage:              7.48%
+
+PIPELINE RUNTIME
+  Total time: 11m 59s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Little_River_log.txt
+++ b/GEE/TIF_Output/Logs/Little_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Little_River
+Date/Time: 2026-04-29 16:39:25
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9625
+  colsample_bytree          0.8
+  gamma                     1.0
+  learning_rate             0.1
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.1
+  reg_lambda                1.5
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9888
+  Accuracy:                0.9563
+
+  Wetland:
+    Precision:             0.8546
+    Recall:                0.9418
+    F1-score:              0.8961
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9851
+    Recall:                0.9599
+    F1-score:              0.9723
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,199               801
+  Actual Wetland                 291             4,709
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.1866
+   2. elev_5x5_std_dev                    0.1821
+   3. tpi_21x21                           0.0706
+   4. soil_ksat_0_5cm                     0.0481
+   5. soil_clay_pct_0_5cm                 0.0407
+   6. soil_clay_pct_5_15cm                0.0387
+   7. tpi_11x11                           0.0297
+   8. tri                                 0.0293
+   9. twi_100m                            0.0280
+  10. soil_organic_matter_15_30cm         0.0273
+  11. soil_ksat_5_15cm                    0.0254
+  12. dd_v                                0.0252
+  13. dd_s                                0.0226
+  14. dd_h                                0.0218
+  15. elev_5x5_rel                        0.0218
+  16. soil_ksat_15_30cm                   0.0198
+  17. soil_organic_matter_5_15cm          0.0195
+  18. soil_clay_pct_15_30cm               0.0193
+  19. aspect                              0.0186
+  20. slope_std_9x9                       0.0183
+  21. soil_organic_matter_0_5cm           0.0172
+  22. slope_5x5_std_dev                   0.0142
+  23. twi_10m                             0.0141
+  24. slope                               0.0137
+  25. curvature_plan                      0.0136
+  26. elev_std_3x3                        0.0131
+  27. curvature_profile                   0.0118
+  28. tpi_3x3                             0.0089
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  245,917
+  Estimated meadow area:        2,459.17 ha
+  Total valid pixels:           5,346,998
+  Meadow coverage:              4.60%
+
+PIPELINE RUNTIME
+  Total time: 11m 52s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Little_Shasta_River_log.txt
+++ b/GEE/TIF_Output/Logs/Little_Shasta_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Little_Shasta_River
+Date/Time: 2026-04-29 16:38:59
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9619
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9735
+  Accuracy:                0.9174
+
+  Wetland:
+    Precision:             0.7267
+    Recall:                0.9406
+    F1-score:              0.8199
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9840
+    Recall:                0.9115
+    F1-score:              0.9464
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                18,231             1,769
+  Actual Wetland                 297             4,703
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.1972
+   2. elev_5x5_std_dev                    0.1793
+   3. tri                                 0.1198
+   4. soil_clay_pct_0_5cm                 0.0479
+   5. soil_ksat_15_30cm                   0.0388
+   6. elev_std_3x3                        0.0360
+   7. soil_clay_pct_5_15cm                0.0348
+   8. tpi_21x21                           0.0344
+   9. dd_v                                0.0331
+  10. soil_organic_matter_15_30cm         0.0258
+  11. soil_organic_matter_5_15cm          0.0258
+  12. soil_ksat_5_15cm                    0.0256
+  13. soil_clay_pct_15_30cm               0.0246
+  14. slope                               0.0205
+  15. soil_organic_matter_0_5cm           0.0169
+  16. twi_100m                            0.0158
+  17. soil_ksat_0_5cm                     0.0157
+  18. dd_h                                0.0138
+  19. slope_std_9x9                       0.0131
+  20. dd_s                                0.0122
+  21. aspect                              0.0118
+  22. slope_5x5_std_dev                   0.0115
+  23. twi_10m                             0.0108
+  24. tpi_11x11                           0.0098
+  25. elev_5x5_rel                        0.0071
+  26. curvature_plan                      0.0069
+  27. curvature_profile                   0.0059
+  28. tpi_3x3                             0.0052
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  361,698
+  Estimated meadow area:        3,616.98 ha
+  Total valid pixels:           3,305,323
+  Meadow coverage:              10.94%
+
+PIPELINE RUNTIME
+  Total time: 11m 8s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Little_Walker_Mountain_log.txt
+++ b/GEE/TIF_Output/Logs/Little_Walker_Mountain_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Little_Walker_Mountain
+Date/Time: 2026-04-29 16:39:20
+================================================================================
+
+DATA SUMMARY
+  Total samples:           23,910
+  Wetland (1):             4,782  (20.0%)
+  Non-wetland (0):         19,128  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            17,932
+  Test set:                5,978
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9924
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0006
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9960
+  Accuracy:                0.9771
+
+  Wetland:
+    Precision:             0.9179
+    Recall:                0.9724
+    F1-score:              0.9444
+    Support:               1,196
+
+  Non-Wetland:
+    Precision:             0.9930
+    Recall:                0.9783
+    F1-score:              0.9856
+    Support:               4,782
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 4,678               104
+  Actual Wetland                  33             1,163
+
+FEATURE IMPORTANCES (ranked)
+   1. tpi_21x21                           0.3115
+   2. soil_organic_matter_5_15cm          0.1554
+   3. soil_ksat_5_15cm                    0.0531
+   4. elev_std_9x9                        0.0352
+   5. dd_v                                0.0340
+   6. dd_s                                0.0295
+   7. soil_ksat_15_30cm                   0.0291
+   8. soil_clay_pct_5_15cm                0.0290
+   9. tpi_11x11                           0.0265
+  10. twi_100m                            0.0261
+  11. dd_h                                0.0258
+  12. soil_clay_pct_0_5cm                 0.0247
+  13. curvature_plan                      0.0207
+  14. slope                               0.0201
+  15. soil_clay_pct_15_30cm               0.0177
+  16. soil_ksat_0_5cm                     0.0169
+  17. slope_5x5_std_dev                   0.0166
+  18. elev_5x5_rel                        0.0149
+  19. slope_std_9x9                       0.0148
+  20. tri                                 0.0140
+  21. soil_organic_matter_15_30cm         0.0139
+  22. twi_10m                             0.0138
+  23. aspect                              0.0134
+  24. curvature_profile                   0.0120
+  25. elev_std_3x3                        0.0097
+  26. soil_organic_matter_0_5cm           0.0088
+  27. elev_5x5_std_dev                    0.0067
+  28. tpi_3x3                             0.0061
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  81,962
+  Estimated meadow area:        819.62 ha
+  Total valid pixels:           3,522,182
+  Meadow coverage:              2.33%
+
+PIPELINE RUNTIME
+  Total time: 11m 37s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Lobster_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Lobster_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Lobster_Creek
+Date/Time: 2026-04-29 16:38:57
+================================================================================
+
+DATA SUMMARY
+  Total samples:           7,925
+  Wetland (1):             1,585  (20.0%)
+  Non-wetland (0):         6,340  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            5,943
+  Test set:                1,982
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9923
+  colsample_bytree          0.8
+  gamma                     1.0
+  learning_rate             0.1
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.1
+  reg_lambda                1.5
+  scale_pos_weight          3.9983
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9906
+  Accuracy:                0.9637
+
+  Wetland:
+    Precision:             0.8750
+    Recall:                0.9545
+    F1-score:              0.9130
+    Support:               396
+
+  Non-Wetland:
+    Precision:             0.9884
+    Recall:                0.9660
+    F1-score:              0.9770
+    Support:               1,586
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 1,532                54
+  Actual Wetland                  18               378
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.4193
+   2. tpi_21x21                           0.0872
+   3. tri                                 0.0355
+   4. elev_std_9x9                        0.0350
+   5. slope_5x5_std_dev                   0.0315
+   6. dd_s                                0.0310
+   7. twi_100m                            0.0296
+   8. elev_std_3x3                        0.0257
+   9. tpi_11x11                           0.0243
+  10. soil_ksat_0_5cm                     0.0241
+  11. soil_clay_pct_0_5cm                 0.0218
+  12. elev_5x5_std_dev                    0.0204
+  13. soil_ksat_15_30cm                   0.0186
+  14. slope_std_9x9                       0.0184
+  15. dd_h                                0.0173
+  16. slope                               0.0160
+  17. soil_clay_pct_5_15cm                0.0155
+  18. aspect                              0.0149
+  19. curvature_plan                      0.0143
+  20. elev_5x5_rel                        0.0128
+  21. soil_clay_pct_15_30cm               0.0122
+  22. soil_ksat_5_15cm                    0.0120
+  23. soil_organic_matter_15_30cm         0.0118
+  24. soil_organic_matter_0_5cm           0.0107
+  25. twi_10m                             0.0107
+  26. soil_organic_matter_5_15cm          0.0105
+  27. tpi_3x3                             0.0096
+  28. curvature_profile                   0.0094
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  66,152
+  Estimated meadow area:        661.52 ha
+  Total valid pixels:           1,797,344
+  Meadow coverage:              3.68%
+
+PIPELINE RUNTIME
+  Total time: 11m 6s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Long_Lake_Valley_Upper_Klamath_Lake_log.txt
+++ b/GEE/TIF_Output/Logs/Long_Lake_Valley_Upper_Klamath_Lake_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Long_Lake_Valley_Upper_Klamath_Lake
+Date/Time: 2026-04-29 16:57:37
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9734
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9828
+  Accuracy:                0.9386
+
+  Wetland:
+    Precision:             0.7898
+    Recall:                0.9446
+    F1-score:              0.8603
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9854
+    Recall:                0.9372
+    F1-score:              0.9607
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                18,743             1,257
+  Actual Wetland                 277             4,723
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.1980
+   2. elev_5x5_std_dev                    0.1611
+   3. soil_clay_pct_15_30cm               0.0818
+   4. elev_std_3x3                        0.0721
+   5. soil_organic_matter_5_15cm          0.0538
+   6. tri                                 0.0453
+   7. soil_clay_pct_5_15cm                0.0398
+   8. dd_v                                0.0395
+   9. soil_organic_matter_0_5cm           0.0386
+  10. soil_ksat_5_15cm                    0.0311
+  11. soil_organic_matter_15_30cm         0.0282
+  12. soil_ksat_0_5cm                     0.0267
+  13. slope_std_9x9                       0.0182
+  14. soil_ksat_15_30cm                   0.0176
+  15. slope_5x5_std_dev                   0.0176
+  16. soil_clay_pct_0_5cm                 0.0176
+  17. slope                               0.0174
+  18. tpi_21x21                           0.0138
+  19. dd_h                                0.0126
+  20. dd_s                                0.0110
+  21. twi_100m                            0.0096
+  22. curvature_plan                      0.0084
+  23. tpi_11x11                           0.0084
+  24. twi_10m                             0.0070
+  25. elev_5x5_rel                        0.0068
+  26. aspect                              0.0067
+  27. tpi_3x3                             0.0062
+  28. curvature_profile                   0.0050
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  2,186,281
+  Estimated meadow area:        21,862.81 ha
+  Total valid pixels:           10,875,713
+  Meadow coverage:              20.10%
+
+PIPELINE RUNTIME
+  Total time: 29m 58s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Lost_Creek_Rogue_River_log.txt
+++ b/GEE/TIF_Output/Logs/Lost_Creek_Rogue_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Lost_Creek_Rogue_River
+Date/Time: 2026-04-29 16:38:57
+================================================================================
+
+DATA SUMMARY
+  Total samples:           6,240
+  Wetland (1):             1,248  (20.0%)
+  Non-wetland (0):         4,992  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            4,680
+  Test set:                1,560
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9934
+  colsample_bytree          1.0
+  gamma                     0.1
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              100
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                1
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9936
+  Accuracy:                0.9699
+
+  Wetland:
+    Precision:             0.8955
+    Recall:                0.9615
+    F1-score:              0.9274
+    Support:               312
+
+  Non-Wetland:
+    Precision:             0.9902
+    Recall:                0.9720
+    F1-score:              0.9810
+    Support:               1,248
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 1,213                35
+  Actual Wetland                  12               300
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.2470
+   2. elev_std_9x9                        0.0732
+   3. soil_clay_pct_0_5cm                 0.0524
+   4. aspect                              0.0508
+   5. twi_100m                            0.0508
+   6. elev_std_3x3                        0.0488
+   7. soil_organic_matter_15_30cm         0.0357
+   8. slope_std_9x9                       0.0351
+   9. dd_h                                0.0325
+  10. soil_organic_matter_0_5cm           0.0304
+  11. dd_s                                0.0262
+  12. slope_5x5_std_dev                   0.0261
+  13. soil_clay_pct_15_30cm               0.0255
+  14. soil_ksat_5_15cm                    0.0230
+  15. soil_ksat_15_30cm                   0.0225
+  16. tri                                 0.0217
+  17. tpi_3x3                             0.0193
+  18. twi_10m                             0.0187
+  19. elev_5x5_std_dev                    0.0181
+  20. soil_organic_matter_5_15cm          0.0179
+  21. tpi_21x21                           0.0169
+  22. elev_5x5_rel                        0.0164
+  23. soil_clay_pct_5_15cm                0.0159
+  24. soil_ksat_0_5cm                     0.0157
+  25. curvature_profile                   0.0155
+  26. tpi_11x11                           0.0155
+  27. slope                               0.0147
+  28. curvature_plan                      0.0134
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  45,174
+  Estimated meadow area:        451.74 ha
+  Total valid pixels:           1,301,601
+  Meadow coverage:              3.47%
+
+PIPELINE RUNTIME
+  Total time: 11m 5s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Lower_Applegate_River_log.txt
+++ b/GEE/TIF_Output/Logs/Lower_Applegate_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Lower_Applegate_River
+Date/Time: 2026-04-29 16:38:59
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9733
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9830
+  Accuracy:                0.9362
+
+  Wetland:
+    Precision:             0.7719
+    Recall:                0.9666
+    F1-score:              0.8584
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9911
+    Recall:                0.9286
+    F1-score:              0.9588
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                18,572             1,428
+  Actual Wetland                 167             4,833
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.2131
+   2. elev_5x5_std_dev                    0.2124
+   3. dd_v                                0.0989
+   4. elev_std_3x3                        0.0937
+   5. soil_clay_pct_15_30cm               0.0400
+   6. tri                                 0.0384
+   7. twi_100m                            0.0247
+   8. slope_std_9x9                       0.0228
+   9. soil_organic_matter_15_30cm         0.0200
+  10. slope_5x5_std_dev                   0.0190
+  11. soil_organic_matter_5_15cm          0.0180
+  12. soil_ksat_0_5cm                     0.0176
+  13. tpi_21x21                           0.0173
+  14. soil_clay_pct_5_15cm                0.0166
+  15. soil_ksat_15_30cm                   0.0163
+  16. soil_clay_pct_0_5cm                 0.0161
+  17. soil_ksat_5_15cm                    0.0157
+  18. soil_organic_matter_0_5cm           0.0146
+  19. curvature_plan                      0.0127
+  20. dd_s                                0.0097
+  21. slope                               0.0096
+  22. dd_h                                0.0096
+  23. aspect                              0.0092
+  24. twi_10m                             0.0085
+  25. tpi_11x11                           0.0083
+  26. curvature_profile                   0.0060
+  27. elev_5x5_rel                        0.0059
+  28. tpi_3x3                             0.0052
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  289,538
+  Estimated meadow area:        2,895.38 ha
+  Total valid pixels:           3,673,617
+  Meadow coverage:              7.88%
+
+PIPELINE RUNTIME
+  Total time: 11m 11s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Lower_Cow_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Lower_Cow_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Lower_Cow_Creek
+Date/Time: 2026-04-29 16:38:57
+================================================================================
+
+DATA SUMMARY
+  Total samples:           55,720
+  Wetland (1):             11,144  (20.0%)
+  Non-wetland (0):         44,576  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            41,790
+  Test set:                13,930
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9954
+  colsample_bytree          1.0
+  gamma                     0.1
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              100
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                1
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9970
+  Accuracy:                0.9811
+
+  Wetland:
+    Precision:             0.9249
+    Recall:                0.9856
+    F1-score:              0.9543
+    Support:               2,786
+
+  Non-Wetland:
+    Precision:             0.9964
+    Recall:                0.9800
+    F1-score:              0.9881
+    Support:               11,144
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                10,921               223
+  Actual Wetland                  40             2,746
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.6460
+   2. dd_v                                0.0590
+   3. curvature_plan                      0.0371
+   4. tpi_21x21                           0.0222
+   5. soil_clay_pct_0_5cm                 0.0172
+   6. slope_5x5_std_dev                   0.0153
+   7. twi_100m                            0.0151
+   8. slope_std_9x9                       0.0149
+   9. soil_ksat_15_30cm                   0.0133
+  10. soil_organic_matter_15_30cm         0.0127
+  11. soil_ksat_0_5cm                     0.0112
+  12. soil_organic_matter_0_5cm           0.0112
+  13. soil_clay_pct_5_15cm                0.0110
+  14. dd_s                                0.0094
+  15. soil_clay_pct_15_30cm               0.0091
+  16. elev_5x5_std_dev                    0.0091
+  17. soil_ksat_5_15cm                    0.0091
+  18. tpi_11x11                           0.0090
+  19. dd_h                                0.0089
+  20. elev_std_3x3                        0.0080
+  21. soil_organic_matter_5_15cm          0.0079
+  22. twi_10m                             0.0076
+  23. aspect                              0.0074
+  24. tri                                 0.0074
+  25. slope                               0.0060
+  26. tpi_3x3                             0.0054
+  27. elev_5x5_rel                        0.0052
+  28. curvature_profile                   0.0042
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  95,293
+  Estimated meadow area:        952.93 ha
+  Total valid pixels:           4,151,663
+  Meadow coverage:              2.30%
+
+PIPELINE RUNTIME
+  Total time: 11m 8s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Lower_Klamath_Lake_log.txt
+++ b/GEE/TIF_Output/Logs/Lower_Klamath_Lake_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Lower_Klamath_Lake
+Date/Time: 2026-04-29 16:49:14
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9349
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9482
+  Accuracy:                0.8743
+
+  Wetland:
+    Precision:             0.6273
+    Recall:                0.9154
+    F1-score:              0.7445
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9761
+    Recall:                0.8640
+    F1-score:              0.9167
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                17,281             2,719
+  Actual Wetland                 423             4,577
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.2028
+   2. elev_5x5_std_dev                    0.1649
+   3. soil_ksat_5_15cm                    0.0850
+   4. slope                               0.0493
+   5. tri                                 0.0485
+   6. soil_organic_matter_15_30cm         0.0453
+   7. elev_std_3x3                        0.0433
+   8. soil_ksat_0_5cm                     0.0337
+   9. dd_v                                0.0329
+  10. soil_organic_matter_5_15cm          0.0315
+  11. soil_clay_pct_0_5cm                 0.0298
+  12. soil_organic_matter_0_5cm           0.0235
+  13. soil_clay_pct_5_15cm                0.0230
+  14. soil_clay_pct_15_30cm               0.0187
+  15. slope_5x5_std_dev                   0.0173
+  16. slope_std_9x9                       0.0167
+  17. soil_ksat_15_30cm                   0.0149
+  18. dd_s                                0.0142
+  19. dd_h                                0.0140
+  20. tpi_21x21                           0.0135
+  21. aspect                              0.0126
+  22. twi_100m                            0.0125
+  23. twi_10m                             0.0113
+  24. curvature_plan                      0.0105
+  25. tpi_11x11                           0.0104
+  26. elev_5x5_rel                        0.0070
+  27. tpi_3x3                             0.0067
+  28. curvature_profile                   0.0065
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  2,074,607
+  Estimated meadow area:        20,746.07 ha
+  Total valid pixels:           8,080,557
+  Meadow coverage:              25.67%
+
+PIPELINE RUNTIME
+  Total time: 21m 33s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Lower_North_Umpqua_River_log.txt
+++ b/GEE/TIF_Output/Logs/Lower_North_Umpqua_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Lower_North_Umpqua_River
+Date/Time: 2026-04-29 16:39:10
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9303
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9431
+  Accuracy:                0.8620
+
+  Wetland:
+    Precision:             0.6055
+    Recall:                0.8902
+    F1-score:              0.7208
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9689
+    Recall:                0.8550
+    F1-score:              0.9084
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                17,100             2,900
+  Actual Wetland                 549             4,451
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_5x5_std_dev                    0.2764
+   2. elev_std_9x9                        0.1610
+   3. elev_std_3x3                        0.0605
+   4. tpi_21x21                           0.0580
+   5. tri                                 0.0537
+   6. twi_100m                            0.0378
+   7. soil_clay_pct_5_15cm                0.0353
+   8. slope                               0.0297
+   9. soil_clay_pct_15_30cm               0.0225
+  10. soil_clay_pct_0_5cm                 0.0217
+  11. soil_ksat_5_15cm                    0.0213
+  12. dd_v                                0.0192
+  13. soil_organic_matter_15_30cm         0.0160
+  14. twi_10m                             0.0158
+  15. soil_ksat_0_5cm                     0.0153
+  16. soil_ksat_15_30cm                   0.0149
+  17. soil_organic_matter_0_5cm           0.0146
+  18. tpi_11x11                           0.0143
+  19. elev_5x5_rel                        0.0136
+  20. soil_organic_matter_5_15cm          0.0133
+  21. aspect                              0.0124
+  22. dd_h                                0.0124
+  23. dd_s                                0.0119
+  24. slope_std_9x9                       0.0110
+  25. slope_5x5_std_dev                   0.0103
+  26. curvature_plan                      0.0100
+  27. curvature_profile                   0.0087
+  28. tpi_3x3                             0.0085
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  772,396
+  Estimated meadow area:        7,723.96 ha
+  Total valid pixels:           4,314,416
+  Meadow coverage:              17.90%
+
+PIPELINE RUNTIME
+  Total time: 11m 27s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Middle_Applegate_River_log.txt
+++ b/GEE/TIF_Output/Logs/Middle_Applegate_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Middle_Applegate_River
+Date/Time: 2026-04-29 16:39:01
+================================================================================
+
+DATA SUMMARY
+  Total samples:           35,645
+  Wetland (1):             7,129  (20.0%)
+  Non-wetland (0):         28,516  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            26,733
+  Test set:                8,912
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9725
+  colsample_bytree          0.8
+  gamma                     1.0
+  learning_rate             0.1
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.1
+  reg_lambda                1.5
+  scale_pos_weight          3.9996
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9853
+  Accuracy:                0.9493
+
+  Wetland:
+    Precision:             0.8206
+    Recall:                0.9551
+    F1-score:              0.8828
+    Support:               1,782
+
+  Non-Wetland:
+    Precision:             0.9883
+    Recall:                0.9478
+    F1-score:              0.9676
+    Support:               7,130
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 6,758               372
+  Actual Wetland                  80             1,702
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.3357
+   2. elev_5x5_std_dev                    0.1028
+   3. elev_std_9x9                        0.0660
+   4. slope_5x5_std_dev                   0.0524
+   5. curvature_plan                      0.0331
+   6. tpi_21x21                           0.0286
+   7. tpi_11x11                           0.0259
+   8. slope_std_9x9                       0.0256
+   9. soil_organic_matter_15_30cm         0.0239
+  10. twi_100m                            0.0221
+  11. soil_clay_pct_0_5cm                 0.0215
+  12. soil_organic_matter_0_5cm           0.0200
+  13. soil_organic_matter_5_15cm          0.0191
+  14. aspect                              0.0189
+  15. soil_ksat_15_30cm                   0.0186
+  16. soil_ksat_5_15cm                    0.0177
+  17. dd_s                                0.0169
+  18. dd_h                                0.0165
+  19. soil_ksat_0_5cm                     0.0158
+  20. twi_10m                             0.0155
+  21. soil_clay_pct_5_15cm                0.0147
+  22. elev_std_3x3                        0.0147
+  23. tri                                 0.0145
+  24. soil_clay_pct_15_30cm               0.0141
+  25. curvature_profile                   0.0118
+  26. elev_5x5_rel                        0.0114
+  27. slope                               0.0113
+  28. tpi_3x3                             0.0111
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  182,690
+  Estimated meadow area:        1,826.90 ha
+  Total valid pixels:           3,349,083
+  Meadow coverage:              5.45%
+
+PIPELINE RUNTIME
+  Total time: 11m 14s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Middle_Cow_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Middle_Cow_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Middle_Cow_Creek
+Date/Time: 2026-04-29 16:38:57
+================================================================================
+
+DATA SUMMARY
+  Total samples:           63,080
+  Wetland (1):             12,616  (20.0%)
+  Non-wetland (0):         50,464  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            47,310
+  Test set:                15,770
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9886
+  colsample_bytree          0.8
+  gamma                     1.0
+  learning_rate             0.1
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.1
+  reg_lambda                1.5
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9941
+  Accuracy:                0.9718
+
+  Wetland:
+    Precision:             0.8856
+    Recall:                0.9864
+    F1-score:              0.9333
+    Support:               3,154
+
+  Non-Wetland:
+    Precision:             0.9965
+    Recall:                0.9681
+    F1-score:              0.9821
+    Support:               12,616
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                12,214               402
+  Actual Wetland                  43             3,111
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.4010
+   2. elev_5x5_std_dev                    0.2510
+   3. dd_v                                0.0420
+   4. tri                                 0.0391
+   5. soil_organic_matter_0_5cm           0.0229
+   6. twi_100m                            0.0186
+   7. slope_std_9x9                       0.0179
+   8. soil_organic_matter_5_15cm          0.0173
+   9. curvature_plan                      0.0169
+  10. soil_organic_matter_15_30cm         0.0139
+  11. slope_5x5_std_dev                   0.0133
+  12. tpi_21x21                           0.0118
+  13. aspect                              0.0106
+  14. elev_std_3x3                        0.0106
+  15. soil_ksat_15_30cm                   0.0104
+  16. soil_clay_pct_5_15cm                0.0103
+  17. soil_ksat_5_15cm                    0.0102
+  18. soil_clay_pct_15_30cm               0.0099
+  19. dd_s                                0.0093
+  20. soil_ksat_0_5cm                     0.0091
+  21. soil_clay_pct_0_5cm                 0.0089
+  22. dd_h                                0.0084
+  23. twi_10m                             0.0072
+  24. elev_5x5_rel                        0.0070
+  25. tpi_11x11                           0.0068
+  26. slope                               0.0056
+  27. tpi_3x3                             0.0055
+  28. curvature_profile                   0.0047
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  145,497
+  Estimated meadow area:        1,454.97 ha
+  Total valid pixels:           4,587,336
+  Meadow coverage:              3.17%
+
+PIPELINE RUNTIME
+  Total time: 11m 11s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Middle_Fork_Coquille_River_log.txt
+++ b/GEE/TIF_Output/Logs/Middle_Fork_Coquille_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Middle_Fork_Coquille_River
+Date/Time: 2026-04-29 16:39:01
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9747
+  colsample_bytree          1.0
+  gamma                     0.5
+  learning_rate             0.1
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                1.5
+  scale_pos_weight          4.0
+  subsample                 0.6
+
+TEST SET PERFORMANCE
+  AUC:                     0.9888
+  Accuracy:                0.9535
+
+  Wetland:
+    Precision:             0.8418
+    Recall:                0.9452
+    F1-score:              0.8905
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9859
+    Recall:                0.9556
+    F1-score:              0.9705
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,112               888
+  Actual Wetland                 274             4,726
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.4476
+   2. elev_std_9x9                        0.0739
+   3. tpi_21x21                           0.0384
+   4. slope_std_9x9                       0.0329
+   5. soil_clay_pct_15_30cm               0.0257
+   6. soil_organic_matter_15_30cm         0.0242
+   7. curvature_plan                      0.0215
+   8. soil_clay_pct_0_5cm                 0.0208
+   9. soil_organic_matter_5_15cm          0.0205
+  10. slope_5x5_std_dev                   0.0204
+  11. soil_organic_matter_0_5cm           0.0200
+  12. tri                                 0.0198
+  13. twi_100m                            0.0196
+  14. soil_ksat_15_30cm                   0.0192
+  15. dd_h                                0.0184
+  16. soil_ksat_5_15cm                    0.0177
+  17. elev_5x5_std_dev                    0.0176
+  18. soil_clay_pct_5_15cm                0.0176
+  19. dd_s                                0.0169
+  20. aspect                              0.0138
+  21. twi_10m                             0.0135
+  22. slope                               0.0135
+  23. soil_ksat_0_5cm                     0.0128
+  24. curvature_profile                   0.0113
+  25. elev_std_3x3                        0.0112
+  26. tpi_11x11                           0.0109
+  27. elev_5x5_rel                        0.0107
+  28. tpi_3x3                             0.0095
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  371,686
+  Estimated meadow area:        3,716.86 ha
+  Total valid pixels:           7,998,124
+  Meadow coverage:              4.65%
+
+PIPELINE RUNTIME
+  Total time: 11m 23s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Middle_Fork_Smith_River_log.txt
+++ b/GEE/TIF_Output/Logs/Middle_Fork_Smith_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Middle_Fork_Smith_River
+Date/Time: 2026-04-29 16:39:02
+================================================================================
+
+DATA SUMMARY
+  Total samples:           39,040
+  Wetland (1):             7,808  (20.0%)
+  Non-wetland (0):         31,232  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            29,280
+  Test set:                9,760
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9467
+  colsample_bytree          0.8
+  gamma                     1.0
+  learning_rate             0.1
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.1
+  reg_lambda                1.5
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9660
+  Accuracy:                0.9162
+
+  Wetland:
+    Precision:             0.7452
+    Recall:                0.8827
+    F1-score:              0.8082
+    Support:               1,952
+
+  Non-Wetland:
+    Precision:             0.9693
+    Recall:                0.9246
+    F1-score:              0.9464
+    Support:               7,808
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 7,219               589
+  Actual Wetland                 229             1,723
+
+FEATURE IMPORTANCES (ranked)
+   1. tpi_21x21                           0.2215
+   2. tpi_11x11                           0.0765
+   3. twi_100m                            0.0496
+   4. dd_v                                0.0486
+   5. dd_s                                0.0443
+   6. elev_std_9x9                        0.0407
+   7. slope_std_9x9                       0.0407
+   8. aspect                              0.0387
+   9. dd_h                                0.0346
+  10. curvature_profile                   0.0269
+  11. soil_clay_pct_15_30cm               0.0257
+  12. elev_5x5_std_dev                    0.0255
+  13. soil_ksat_0_5cm                     0.0245
+  14. slope_5x5_std_dev                   0.0241
+  15. twi_10m                             0.0239
+  16. soil_clay_pct_0_5cm                 0.0217
+  17. elev_5x5_rel                        0.0208
+  18. soil_organic_matter_5_15cm          0.0205
+  19. soil_clay_pct_5_15cm                0.0204
+  20. soil_ksat_5_15cm                    0.0201
+  21. tri                                 0.0197
+  22. elev_std_3x3                        0.0197
+  23. soil_organic_matter_15_30cm         0.0196
+  24. slope                               0.0192
+  25. soil_ksat_15_30cm                   0.0190
+  26. soil_organic_matter_0_5cm           0.0179
+  27. curvature_plan                      0.0178
+  28. tpi_3x3                             0.0177
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  264,471
+  Estimated meadow area:        2,644.71 ha
+  Total valid pixels:           3,396,687
+  Meadow coverage:              7.79%
+
+PIPELINE RUNTIME
+  Total time: 11m 19s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Middle_North_Umpqua_River_log.txt
+++ b/GEE/TIF_Output/Logs/Middle_North_Umpqua_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Middle_North_Umpqua_River
+Date/Time: 2026-04-29 16:39:11
+================================================================================
+
+DATA SUMMARY
+  Total samples:           38,315
+  Wetland (1):             7,663  (20.0%)
+  Non-wetland (0):         30,652  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            28,736
+  Test set:                9,579
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9747
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0002
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9910
+  Accuracy:                0.9621
+
+  Wetland:
+    Precision:             0.8812
+    Recall:                0.9368
+    F1-score:              0.9082
+    Support:               1,916
+
+  Non-Wetland:
+    Precision:             0.9840
+    Recall:                0.9684
+    F1-score:              0.9761
+    Support:               7,663
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 7,421               242
+  Actual Wetland                 121             1,795
+
+FEATURE IMPORTANCES (ranked)
+   1. soil_clay_pct_0_5cm                 0.1478
+   2. soil_ksat_15_30cm                   0.1300
+   3. tpi_21x21                           0.1263
+   4. elev_std_9x9                        0.1106
+   5. tpi_11x11                           0.0411
+   6. twi_100m                            0.0316
+   7. dd_v                                0.0298
+   8. soil_clay_pct_15_30cm               0.0296
+   9. twi_10m                             0.0255
+  10. aspect                              0.0254
+  11. soil_ksat_5_15cm                    0.0248
+  12. dd_s                                0.0228
+  13. slope                               0.0218
+  14. soil_ksat_0_5cm                     0.0213
+  15. soil_organic_matter_5_15cm          0.0199
+  16. elev_5x5_std_dev                    0.0182
+  17. curvature_profile                   0.0181
+  18. soil_organic_matter_15_30cm         0.0177
+  19. slope_std_9x9                       0.0175
+  20. soil_clay_pct_5_15cm                0.0174
+  21. dd_h                                0.0170
+  22. soil_organic_matter_0_5cm           0.0166
+  23. elev_std_3x3                        0.0143
+  24. slope_5x5_std_dev                   0.0135
+  25. curvature_plan                      0.0125
+  26. tri                                 0.0114
+  27. elev_5x5_rel                        0.0098
+  28. tpi_3x3                             0.0077
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  198,755
+  Estimated meadow area:        1,987.55 ha
+  Total valid pixels:           5,879,633
+  Meadow coverage:              3.38%
+
+PIPELINE RUNTIME
+  Total time: 11m 33s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Myrtle_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Myrtle_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Myrtle_Creek
+Date/Time: 2026-04-29 16:38:59
+================================================================================
+
+DATA SUMMARY
+  Total samples:           78,530
+  Wetland (1):             15,706  (20.0%)
+  Non-wetland (0):         62,824  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            58,897
+  Test set:                19,633
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9824
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0002
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9940
+  Accuracy:                0.9706
+
+  Wetland:
+    Precision:             0.8838
+    Recall:                0.9819
+    F1-score:              0.9303
+    Support:               3,927
+
+  Non-Wetland:
+    Precision:             0.9954
+    Recall:                0.9677
+    F1-score:              0.9813
+    Support:               15,706
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                15,199               507
+  Actual Wetland                  71             3,856
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.2896
+   2. elev_5x5_std_dev                    0.2072
+   3. soil_organic_matter_0_5cm           0.0997
+   4. dd_v                                0.0551
+   5. soil_ksat_0_5cm                     0.0290
+   6. soil_organic_matter_15_30cm         0.0285
+   7. twi_100m                            0.0265
+   8. slope_std_9x9                       0.0234
+   9. tpi_21x21                           0.0233
+  10. soil_clay_pct_5_15cm                0.0211
+  11. dd_h                                0.0182
+  12. aspect                              0.0161
+  13. soil_ksat_15_30cm                   0.0152
+  14. soil_clay_pct_15_30cm               0.0145
+  15. soil_ksat_5_15cm                    0.0137
+  16. dd_s                                0.0122
+  17. soil_organic_matter_5_15cm          0.0122
+  18. slope_5x5_std_dev                   0.0116
+  19. slope                               0.0111
+  20. soil_clay_pct_0_5cm                 0.0108
+  21. tri                                 0.0101
+  22. elev_std_3x3                        0.0094
+  23. tpi_11x11                           0.0093
+  24. twi_10m                             0.0089
+  25. curvature_plan                      0.0074
+  26. elev_5x5_rel                        0.0055
+  27. tpi_3x3                             0.0054
+  28. curvature_profile                   0.0051
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  111,632
+  Estimated meadow area:        1,116.32 ha
+  Total valid pixels:           3,091,793
+  Meadow coverage:              3.61%
+
+PIPELINE RUNTIME
+  Total time: 11m 10s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/New_River_Frontal_Pacific_Ocean_log.txt
+++ b/GEE/TIF_Output/Logs/New_River_Frontal_Pacific_Ocean_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: New_River_Frontal_Pacific_Ocean
+Date/Time: 2026-04-29 16:39:10
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9575
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9664
+  Accuracy:                0.8961
+
+  Wetland:
+    Precision:             0.6807
+    Recall:                0.9048
+    F1-score:              0.7769
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9741
+    Recall:                0.8939
+    F1-score:              0.9323
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                17,878             2,122
+  Actual Wetland                 476             4,524
+
+FEATURE IMPORTANCES (ranked)
+   1. tri                                 0.2748
+   2. elev_std_9x9                        0.2145
+   3. elev_5x5_std_dev                    0.0863
+   4. soil_ksat_0_5cm                     0.0616
+   5. dd_v                                0.0345
+   6. elev_std_3x3                        0.0296
+   7. soil_ksat_5_15cm                    0.0288
+   8. soil_clay_pct_15_30cm               0.0240
+   9. slope                               0.0209
+  10. soil_clay_pct_5_15cm                0.0195
+  11. soil_ksat_15_30cm                   0.0169
+  12. tpi_21x21                           0.0162
+  13. soil_clay_pct_0_5cm                 0.0152
+  14. twi_100m                            0.0149
+  15. soil_organic_matter_5_15cm          0.0145
+  16. curvature_plan                      0.0143
+  17. soil_organic_matter_0_5cm           0.0126
+  18. soil_organic_matter_15_30cm         0.0121
+  19. slope_5x5_std_dev                   0.0111
+  20. slope_std_9x9                       0.0101
+  21. twi_10m                             0.0095
+  22. aspect                              0.0092
+  23. tpi_11x11                           0.0090
+  24. dd_h                                0.0089
+  25. dd_s                                0.0089
+  26. elev_5x5_rel                        0.0080
+  27. curvature_profile                   0.0075
+  28. tpi_3x3                             0.0068
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  709,297
+  Estimated meadow area:        7,092.97 ha
+  Total valid pixels:           4,028,547
+  Meadow coverage:              17.61%
+
+PIPELINE RUNTIME
+  Total time: 11m 27s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/North_Fork_Coquille_River_log.txt
+++ b/GEE/TIF_Output/Logs/North_Fork_Coquille_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: North_Fork_Coquille_River
+Date/Time: 2026-04-29 16:38:59
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9845
+  colsample_bytree          0.8
+  gamma                     1.0
+  learning_rate             0.1
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.1
+  reg_lambda                1.5
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9923
+  Accuracy:                0.9629
+
+  Wetland:
+    Precision:             0.8547
+    Recall:                0.9814
+    F1-score:              0.9137
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9952
+    Recall:                0.9583
+    F1-score:              0.9764
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,166               834
+  Actual Wetland                  93             4,907
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.3440
+   2. elev_5x5_std_dev                    0.2237
+   3. dd_v                                0.0969
+   4. soil_ksat_0_5cm                     0.0450
+   5. tri                                 0.0316
+   6. soil_organic_matter_5_15cm          0.0200
+   7. soil_clay_pct_15_30cm               0.0198
+   8. soil_organic_matter_15_30cm         0.0183
+   9. tpi_21x21                           0.0161
+  10. soil_organic_matter_0_5cm           0.0160
+  11. soil_ksat_15_30cm                   0.0147
+  12. soil_ksat_5_15cm                    0.0133
+  13. soil_clay_pct_0_5cm                 0.0125
+  14. twi_100m                            0.0108
+  15. slope_std_9x9                       0.0108
+  16. soil_clay_pct_5_15cm                0.0106
+  17. elev_std_3x3                        0.0105
+  18. curvature_plan                      0.0097
+  19. dd_s                                0.0094
+  20. dd_h                                0.0090
+  21. tpi_11x11                           0.0089
+  22. slope_5x5_std_dev                   0.0088
+  23. aspect                              0.0078
+  24. elev_5x5_rel                        0.0071
+  25. twi_10m                             0.0065
+  26. slope                               0.0064
+  27. curvature_profile                   0.0063
+  28. tpi_3x3                             0.0055
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  198,634
+  Estimated meadow area:        1,986.34 ha
+  Total valid pixels:           3,990,782
+  Meadow coverage:              4.98%
+
+PIPELINE RUNTIME
+  Total time: 11m 12s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/North_Fork_Smith_River_log.txt
+++ b/GEE/TIF_Output/Logs/North_Fork_Smith_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: North_Fork_Smith_River
+Date/Time: 2026-04-29 16:39:12
+================================================================================
+
+DATA SUMMARY
+  Total samples:           21,920
+  Wetland (1):             4,384  (20.0%)
+  Non-wetland (0):         17,536  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            16,440
+  Test set:                5,480
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9770
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9826
+  Accuracy:                0.9505
+
+  Wetland:
+    Precision:             0.8511
+    Recall:                0.9124
+    F1-score:              0.8807
+    Support:               1,096
+
+  Non-Wetland:
+    Precision:             0.9777
+    Recall:                0.9601
+    F1-score:              0.9688
+    Support:               4,384
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 4,209               175
+  Actual Wetland                  96             1,000
+
+FEATURE IMPORTANCES (ranked)
+   1. tpi_21x21                           0.4185
+   2. twi_100m                            0.0627
+   3. dd_s                                0.0398
+   4. slope_std_9x9                       0.0343
+   5. elev_std_9x9                        0.0334
+   6. soil_clay_pct_0_5cm                 0.0278
+   7. soil_clay_pct_15_30cm               0.0266
+   8. soil_clay_pct_5_15cm                0.0246
+   9. dd_h                                0.0244
+  10. aspect                              0.0226
+  11. soil_organic_matter_15_30cm         0.0197
+  12. elev_std_3x3                        0.0194
+  13. tpi_11x11                           0.0190
+  14. twi_10m                             0.0180
+  15. soil_ksat_0_5cm                     0.0178
+  16. dd_v                                0.0177
+  17. soil_ksat_5_15cm                    0.0175
+  18. curvature_plan                      0.0164
+  19. slope                               0.0160
+  20. curvature_profile                   0.0153
+  21. elev_5x5_std_dev                    0.0153
+  22. tri                                 0.0152
+  23. soil_organic_matter_0_5cm           0.0148
+  24. slope_5x5_std_dev                   0.0140
+  25. soil_ksat_15_30cm                   0.0139
+  26. elev_5x5_rel                        0.0132
+  27. soil_organic_matter_5_15cm          0.0132
+  28. tpi_3x3                             0.0090
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  171,703
+  Estimated meadow area:        1,717.03 ha
+  Total valid pixels:           4,100,826
+  Meadow coverage:              4.19%
+
+PIPELINE RUNTIME
+  Total time: 11m 29s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Olalla_Creek_Lookingglass_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Olalla_Creek_Lookingglass_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Olalla_Creek_Lookingglass_Creek
+Date/Time: 2026-04-29 16:39:02
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9707
+  colsample_bytree          0.8
+  gamma                     0
+  learning_rate             0.05
+  max_depth                 6
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                1
+  scale_pos_weight          4.0
+  subsample                 0.6
+
+TEST SET PERFORMANCE
+  AUC:                     0.9761
+  Accuracy:                0.9085
+
+  Wetland:
+    Precision:             0.7006
+    Recall:                0.9472
+    F1-score:              0.8054
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9855
+    Recall:                0.8988
+    F1-score:              0.9402
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                17,976             2,024
+  Actual Wetland                 264             4,736
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_5x5_std_dev                    0.3298
+   2. elev_std_9x9                        0.2976
+   3. tri                                 0.0524
+   4. soil_ksat_0_5cm                     0.0341
+   5. soil_ksat_5_15cm                    0.0286
+   6. soil_ksat_15_30cm                   0.0234
+   7. tpi_21x21                           0.0189
+   8. dd_v                                0.0187
+   9. soil_clay_pct_0_5cm                 0.0162
+  10. soil_organic_matter_15_30cm         0.0157
+  11. soil_organic_matter_5_15cm          0.0141
+  12. soil_clay_pct_5_15cm                0.0128
+  13. soil_organic_matter_0_5cm           0.0119
+  14. aspect                              0.0117
+  15. soil_clay_pct_15_30cm               0.0111
+  16. elev_std_3x3                        0.0105
+  17. dd_h                                0.0098
+  18. dd_s                                0.0091
+  19. twi_100m                            0.0091
+  20. slope                               0.0086
+  21. tpi_11x11                           0.0084
+  22. slope_std_9x9                       0.0084
+  23. elev_5x5_rel                        0.0075
+  24. twi_10m                             0.0073
+  25. slope_5x5_std_dev                   0.0066
+  26. tpi_3x3                             0.0061
+  27. curvature_plan                      0.0060
+  28. curvature_profile                   0.0056
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  503,334
+  Estimated meadow area:        5,033.34 ha
+  Total valid pixels:           4,182,570
+  Meadow coverage:              12.03%
+
+PIPELINE RUNTIME
+  Total time: 11m 17s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Pistol_River_log.txt
+++ b/GEE/TIF_Output/Logs/Pistol_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Pistol_River
+Date/Time: 2026-04-29 16:39:02
+================================================================================
+
+DATA SUMMARY
+  Total samples:           39,170
+  Wetland (1):             7,834  (20.0%)
+  Non-wetland (0):         31,336  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            29,377
+  Test set:                9,793
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9888
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0003
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9920
+  Accuracy:                0.9669
+
+  Wetland:
+    Precision:             0.8928
+    Recall:                0.9484
+    F1-score:              0.9198
+    Support:               1,959
+
+  Non-Wetland:
+    Precision:             0.9869
+    Recall:                0.9715
+    F1-score:              0.9792
+    Support:               7,834
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 7,611               223
+  Actual Wetland                 101             1,858
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_5x5_std_dev                    0.3282
+   2. elev_std_9x9                        0.1388
+   3. tri                                 0.1241
+   4. tpi_21x21                           0.0636
+   5. elev_std_3x3                        0.0345
+   6. dd_v                                0.0318
+   7. slope_5x5_std_dev                   0.0216
+   8. curvature_plan                      0.0208
+   9. slope                               0.0202
+  10. aspect                              0.0150
+  11. tpi_11x11                           0.0150
+  12. twi_100m                            0.0139
+  13. soil_ksat_15_30cm                   0.0134
+  14. slope_std_9x9                       0.0123
+  15. soil_organic_matter_0_5cm           0.0120
+  16. elev_5x5_rel                        0.0117
+  17. soil_clay_pct_5_15cm                0.0116
+  18. soil_clay_pct_0_5cm                 0.0114
+  19. soil_organic_matter_15_30cm         0.0114
+  20. soil_clay_pct_15_30cm               0.0108
+  21. dd_s                                0.0104
+  22. soil_organic_matter_5_15cm          0.0103
+  23. soil_ksat_5_15cm                    0.0101
+  24. soil_ksat_0_5cm                     0.0098
+  25. dd_h                                0.0097
+  26. twi_10m                             0.0094
+  27. tpi_3x3                             0.0091
+  28. curvature_profile                   0.0091
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  71,784
+  Estimated meadow area:        717.84 ha
+  Total valid pixels:           2,726,670
+  Meadow coverage:              2.63%
+
+PIPELINE RUNTIME
+  Total time: 11m 16s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Point_Saint_George_Frontal_Pacific_Ocean_log.txt
+++ b/GEE/TIF_Output/Logs/Point_Saint_George_Frontal_Pacific_Ocean_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Point_Saint_George_Frontal_Pacific_Ocean
+Date/Time: 2026-04-29 16:41:38
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9123
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9386
+  Accuracy:                0.8493
+
+  Wetland:
+    Precision:             0.5807
+    Recall:                0.8874
+    F1-score:              0.7020
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9676
+    Recall:                0.8398
+    F1-score:              0.8992
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                16,796             3,204
+  Actual Wetland                 563             4,437
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_5x5_std_dev                    0.2096
+   2. elev_std_9x9                        0.1447
+   3. tri                                 0.0717
+   4. dd_v                                0.0520
+   5. slope                               0.0463
+   6. elev_std_3x3                        0.0334
+   7. tpi_21x21                           0.0324
+   8. twi_100m                            0.0318
+   9. soil_clay_pct_15_30cm               0.0272
+  10. soil_clay_pct_5_15cm                0.0264
+  11. slope_std_9x9                       0.0257
+  12. soil_organic_matter_15_30cm         0.0253
+  13. soil_ksat_5_15cm                    0.0250
+  14. soil_organic_matter_0_5cm           0.0231
+  15. dd_h                                0.0216
+  16. soil_clay_pct_0_5cm                 0.0207
+  17. soil_organic_matter_5_15cm          0.0203
+  18. aspect                              0.0197
+  19. dd_s                                0.0190
+  20. soil_ksat_15_30cm                   0.0188
+  21. slope_5x5_std_dev                   0.0185
+  22. soil_ksat_0_5cm                     0.0170
+  23. curvature_plan                      0.0147
+  24. twi_10m                             0.0137
+  25. tpi_11x11                           0.0125
+  26. elev_5x5_rel                        0.0108
+  27. curvature_profile                   0.0093
+  28. tpi_3x3                             0.0092
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  528,261
+  Estimated meadow area:        5,282.61 ha
+  Total valid pixels:           1,865,442
+  Meadow coverage:              28.32%
+
+PIPELINE RUNTIME
+  Total time: 13m 49s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Red_Rock_Valley_Antelope_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Red_Rock_Valley_Antelope_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Red_Rock_Valley_Antelope_Creek
+Date/Time: 2026-04-29 16:39:24
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9723
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9926
+  Accuracy:                0.9683
+
+  Wetland:
+    Precision:             0.9041
+    Recall:                0.9414
+    F1-score:              0.9224
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9852
+    Recall:                0.9750
+    F1-score:              0.9801
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,501               499
+  Actual Wetland                 293             4,707
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_5x5_std_dev                    0.1790
+   2. slope                               0.1349
+   3. dd_h                                0.1014
+   4. dd_v                                0.0707
+   5. dd_s                                0.0456
+   6. elev_std_9x9                        0.0386
+   7. tpi_21x21                           0.0383
+   8. soil_organic_matter_15_30cm         0.0353
+   9. twi_10m                             0.0335
+  10. soil_clay_pct_15_30cm               0.0302
+  11. soil_organic_matter_5_15cm          0.0287
+  12. soil_clay_pct_0_5cm                 0.0287
+  13. aspect                              0.0263
+  14. twi_100m                            0.0238
+  15. soil_clay_pct_5_15cm                0.0208
+  16. soil_ksat_0_5cm                     0.0205
+  17. soil_organic_matter_0_5cm           0.0204
+  18. slope_std_9x9                       0.0200
+  19. soil_ksat_15_30cm                   0.0160
+  20. soil_ksat_5_15cm                    0.0159
+  21. tpi_11x11                           0.0123
+  22. tri                                 0.0109
+  23. elev_std_3x3                        0.0109
+  24. slope_5x5_std_dev                   0.0104
+  25. curvature_profile                   0.0089
+  26. curvature_plan                      0.0078
+  27. elev_5x5_rel                        0.0051
+  28. tpi_3x3                             0.0050
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  156,272
+  Estimated meadow area:        1,562.72 ha
+  Total valid pixels:           4,234,227
+  Meadow coverage:              3.69%
+
+PIPELINE RUNTIME
+  Total time: 11m 51s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Rock_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Rock_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Rock_Creek
+Date/Time: 2026-04-29 16:39:02
+================================================================================
+
+DATA SUMMARY
+  Total samples:           24,305
+  Wetland (1):             4,861  (20.0%)
+  Non-wetland (0):         19,444  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            18,228
+  Test set:                6,077
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9750
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          3.9995
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9836
+  Accuracy:                0.9487
+
+  Wetland:
+    Precision:             0.8428
+    Recall:                0.9136
+    F1-score:              0.8768
+    Support:               1,215
+
+  Non-Wetland:
+    Precision:             0.9779
+    Recall:                0.9574
+    F1-score:              0.9676
+    Support:               4,862
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 4,655               207
+  Actual Wetland                 105             1,110
+
+FEATURE IMPORTANCES (ranked)
+   1. tpi_21x21                           0.2934
+   2. elev_std_9x9                        0.1066
+   3. soil_clay_pct_5_15cm                0.0700
+   4. slope                               0.0624
+   5. dd_h                                0.0426
+   6. elev_5x5_std_dev                    0.0365
+   7. twi_100m                            0.0309
+   8. dd_v                                0.0307
+   9. dd_s                                0.0256
+  10. soil_organic_matter_15_30cm         0.0229
+  11. soil_clay_pct_0_5cm                 0.0223
+  12. soil_ksat_15_30cm                   0.0223
+  13. tri                                 0.0222
+  14. aspect                              0.0197
+  15. tpi_11x11                           0.0188
+  16. soil_clay_pct_15_30cm               0.0170
+  17. slope_std_9x9                       0.0167
+  18. curvature_plan                      0.0151
+  19. soil_ksat_5_15cm                    0.0150
+  20. soil_ksat_0_5cm                     0.0145
+  21. soil_organic_matter_0_5cm           0.0141
+  22. elev_5x5_rel                        0.0139
+  23. slope_5x5_std_dev                   0.0134
+  24. soil_organic_matter_5_15cm          0.0120
+  25. twi_10m                             0.0118
+  26. elev_std_3x3                        0.0117
+  27. tpi_3x3                             0.0098
+  28. curvature_profile                   0.0081
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  106,170
+  Estimated meadow area:        1,061.70 ha
+  Total valid pixels:           2,543,673
+  Meadow coverage:              4.17%
+
+PIPELINE RUNTIME
+  Total time: 11m 16s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Rogue_River_log.txt
+++ b/GEE/TIF_Output/Logs/Rogue_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Rogue_River
+Date/Time: 2026-04-29 16:39:02
+================================================================================
+
+DATA SUMMARY
+  Total samples:           61,585
+  Wetland (1):             12,317  (20.0%)
+  Non-wetland (0):         49,268  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            46,188
+  Test set:                15,397
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9737
+  colsample_bytree          1.0
+  gamma                     0.1
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              100
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                1
+  scale_pos_weight          3.9998
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9858
+  Accuracy:                0.9517
+
+  Wetland:
+    Precision:             0.8499
+    Recall:                0.9211
+    F1-score:              0.8840
+    Support:               3,079
+
+  Non-Wetland:
+    Precision:             0.9799
+    Recall:                0.9593
+    F1-score:              0.9695
+    Support:               12,318
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                11,817               501
+  Actual Wetland                 243             2,836
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_5x5_std_dev                    0.2686
+   2. tri                                 0.2564
+   3. tpi_21x21                           0.0808
+   4. dd_v                                0.0521
+   5. elev_std_9x9                        0.0450
+   6. twi_100m                            0.0188
+   7. curvature_plan                      0.0172
+   8. slope_5x5_std_dev                   0.0161
+   9. soil_clay_pct_0_5cm                 0.0154
+  10. elev_std_3x3                        0.0152
+  11. slope_std_9x9                       0.0144
+  12. tpi_11x11                           0.0144
+  13. soil_ksat_0_5cm                     0.0140
+  14. soil_ksat_15_30cm                   0.0133
+  15. soil_clay_pct_5_15cm                0.0133
+  16. soil_organic_matter_15_30cm         0.0132
+  17. twi_10m                             0.0130
+  18. soil_organic_matter_0_5cm           0.0129
+  19. soil_ksat_5_15cm                    0.0125
+  20. dd_h                                0.0117
+  21. soil_organic_matter_5_15cm          0.0116
+  22. dd_s                                0.0113
+  23. soil_clay_pct_15_30cm               0.0112
+  24. aspect                              0.0112
+  25. slope                               0.0103
+  26. elev_5x5_rel                        0.0090
+  27. tpi_3x3                             0.0087
+  28. curvature_profile                   0.0086
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  148,237
+  Estimated meadow area:        1,482.37 ha
+  Total valid pixels:           3,274,276
+  Meadow coverage:              4.53%
+
+PIPELINE RUNTIME
+  Total time: 11m 15s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Seiad_Creek_Klamath_River_log.txt
+++ b/GEE/TIF_Output/Logs/Seiad_Creek_Klamath_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Seiad_Creek_Klamath_River
+Date/Time: 2026-04-29 16:39:02
+================================================================================
+
+DATA SUMMARY
+  Total samples:           47,030
+  Wetland (1):             9,406  (20.0%)
+  Non-wetland (0):         37,624  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            35,272
+  Test set:                11,758
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9794
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0003
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9927
+  Accuracy:                0.9665
+
+  Wetland:
+    Precision:             0.8916
+    Recall:                0.9477
+    F1-score:              0.9188
+    Support:               2,352
+
+  Non-Wetland:
+    Precision:             0.9867
+    Recall:                0.9712
+    F1-score:              0.9789
+    Support:               9,406
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 9,135               271
+  Actual Wetland                 123             2,229
+
+FEATURE IMPORTANCES (ranked)
+   1. twi_100m                            0.2350
+   2. dd_v                                0.1871
+   3. elev_std_9x9                        0.1179
+   4. elev_5x5_std_dev                    0.0371
+   5. slope_std_9x9                       0.0369
+   6. aspect                              0.0288
+   7. soil_organic_matter_0_5cm           0.0280
+   8. dd_h                                0.0271
+   9. tpi_21x21                           0.0256
+  10. dd_s                                0.0224
+  11. soil_ksat_15_30cm                   0.0211
+  12. soil_ksat_0_5cm                     0.0178
+  13. soil_organic_matter_5_15cm          0.0175
+  14. soil_clay_pct_0_5cm                 0.0172
+  15. slope                               0.0161
+  16. soil_organic_matter_15_30cm         0.0158
+  17. soil_ksat_5_15cm                    0.0157
+  18. soil_clay_pct_5_15cm                0.0153
+  19. tpi_11x11                           0.0147
+  20. soil_clay_pct_15_30cm               0.0141
+  21. twi_10m                             0.0132
+  22. elev_5x5_rel                        0.0123
+  23. curvature_profile                   0.0121
+  24. tri                                 0.0120
+  25. slope_5x5_std_dev                   0.0120
+  26. elev_std_3x3                        0.0101
+  27. curvature_plan                      0.0093
+  28. tpi_3x3                             0.0080
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  112,107
+  Estimated meadow area:        1,121.07 ha
+  Total valid pixels:           3,315,206
+  Meadow coverage:              3.38%
+
+PIPELINE RUNTIME
+  Total time: 11m 18s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Shady_Cove_Rogue_River_log.txt
+++ b/GEE/TIF_Output/Logs/Shady_Cove_Rogue_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Shady_Cove_Rogue_River
+Date/Time: 2026-04-29 16:39:02
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9717
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9832
+  Accuracy:                0.9331
+
+  Wetland:
+    Precision:             0.7715
+    Recall:                0.9458
+    F1-score:              0.8498
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9856
+    Recall:                0.9300
+    F1-score:              0.9570
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                18,599             1,401
+  Actual Wetland                 271             4,729
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.2866
+   2. elev_5x5_std_dev                    0.2319
+   3. slope                               0.0721
+   4. tri                                 0.0490
+   5. elev_std_3x3                        0.0468
+   6. dd_v                                0.0216
+   7. twi_100m                            0.0207
+   8. soil_clay_pct_5_15cm                0.0205
+   9. soil_clay_pct_0_5cm                 0.0187
+  10. soil_clay_pct_15_30cm               0.0173
+  11. soil_ksat_0_5cm                     0.0171
+  12. tpi_21x21                           0.0159
+  13. soil_ksat_5_15cm                    0.0156
+  14. slope_std_9x9                       0.0142
+  15. soil_organic_matter_0_5cm           0.0137
+  16. soil_organic_matter_15_30cm         0.0137
+  17. slope_5x5_std_dev                   0.0134
+  18. soil_organic_matter_5_15cm          0.0134
+  19. soil_ksat_15_30cm                   0.0133
+  20. dd_h                                0.0133
+  21. dd_s                                0.0129
+  22. aspect                              0.0111
+  23. tpi_11x11                           0.0100
+  24. curvature_plan                      0.0089
+  25. twi_10m                             0.0085
+  26. tpi_3x3                             0.0067
+  27. elev_5x5_rel                        0.0067
+  28. curvature_profile                   0.0064
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  246,565
+  Estimated meadow area:        2,465.65 ha
+  Total valid pixels:           3,011,833
+  Meadow coverage:              8.19%
+
+PIPELINE RUNTIME
+  Total time: 11m 16s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Shasta_Costa_Creek_Rogue_River_log.txt
+++ b/GEE/TIF_Output/Logs/Shasta_Costa_Creek_Rogue_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Shasta_Costa_Creek_Rogue_River
+Date/Time: 2026-04-29 16:39:02
+================================================================================
+
+DATA SUMMARY
+  Total samples:           7,260
+  Wetland (1):             1,452  (20.0%)
+  Non-wetland (0):         5,808  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            5,445
+  Test set:                1,815
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9930
+  colsample_bytree          1.0
+  gamma                     0.1
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              100
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                1
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9939
+  Accuracy:                0.9664
+
+  Wetland:
+    Precision:             0.8756
+    Recall:                0.9697
+    F1-score:              0.9203
+    Support:               363
+
+  Non-Wetland:
+    Precision:             0.9922
+    Recall:                0.9656
+    F1-score:              0.9787
+    Support:               1,452
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 1,402                50
+  Actual Wetland                  11               352
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.2804
+   2. elev_std_9x9                        0.1008
+   3. tpi_21x21                           0.0670
+   4. twi_100m                            0.0611
+   5. soil_clay_pct_5_15cm                0.0603
+   6. soil_clay_pct_0_5cm                 0.0372
+   7. elev_5x5_std_dev                    0.0328
+   8. slope                               0.0299
+   9. dd_s                                0.0278
+  10. curvature_plan                      0.0270
+  11. soil_ksat_5_15cm                    0.0248
+  12. soil_ksat_0_5cm                     0.0232
+  13. slope_std_9x9                       0.0229
+  14. aspect                              0.0210
+  15. twi_10m                             0.0174
+  16. tpi_11x11                           0.0174
+  17. soil_ksat_15_30cm                   0.0155
+  18. soil_organic_matter_5_15cm          0.0154
+  19. tri                                 0.0148
+  20. dd_h                                0.0139
+  21. slope_5x5_std_dev                   0.0138
+  22. soil_clay_pct_15_30cm               0.0131
+  23. soil_organic_matter_15_30cm         0.0131
+  24. curvature_profile                   0.0119
+  25. elev_5x5_rel                        0.0116
+  26. soil_organic_matter_0_5cm           0.0105
+  27. elev_std_3x3                        0.0095
+  28. tpi_3x3                             0.0059
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  55,416
+  Estimated meadow area:        554.16 ha
+  Total valid pixels:           1,826,902
+  Meadow coverage:              3.03%
+
+PIPELINE RUNTIME
+  Total time: 11m 14s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Silver_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Silver_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Silver_Creek
+Date/Time: 2026-04-29 16:38:06
+================================================================================
+
+DATA SUMMARY
+  Total samples:           155
+  Wetland (1):             31  (20.0%)
+  Non-wetland (0):         124  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            116
+  Test set:                39
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9960
+  colsample_bytree          0.6
+  gamma                     1.0
+  learning_rate             0.1
+  max_depth                 3
+  min_child_weight          3
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                1.5
+  scale_pos_weight          4.0435
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     1.0000
+  Accuracy:                1.0000
+
+  Wetland:
+    Precision:             1.0000
+    Recall:                1.0000
+    F1-score:              1.0000
+    Support:               8
+
+  Non-Wetland:
+    Precision:             1.0000
+    Recall:                1.0000
+    F1-score:              1.0000
+    Support:               31
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                    31                 0
+  Actual Wetland                   0                 8
+
+FEATURE IMPORTANCES (ranked)
+   1. tpi_21x21                           0.1707
+   2. dd_s                                0.1139
+   3. soil_ksat_5_15cm                    0.0880
+   4. soil_organic_matter_15_30cm         0.0863
+   5. soil_ksat_0_5cm                     0.0849
+   6. slope_std_9x9                       0.0847
+   7. soil_clay_pct_0_5cm                 0.0506
+   8. soil_organic_matter_0_5cm           0.0490
+   9. dd_v                                0.0434
+  10. tri                                 0.0400
+  11. soil_clay_pct_15_30cm               0.0274
+  12. soil_clay_pct_5_15cm                0.0263
+  13. slope_5x5_std_dev                   0.0255
+  14. soil_organic_matter_5_15cm          0.0242
+  15. elev_5x5_std_dev                    0.0166
+  16. elev_std_3x3                        0.0159
+  17. elev_5x5_rel                        0.0140
+  18. slope                               0.0109
+  19. aspect                              0.0103
+  20. curvature_profile                   0.0096
+  21. twi_10m                             0.0080
+  22. soil_ksat_15_30cm                   0.0000
+  23. elev_std_9x9                        0.0000
+  24. tpi_11x11                           0.0000
+  25. curvature_plan                      0.0000
+  26. tpi_3x3                             0.0000
+  27. twi_100m                            0.0000
+  28. dd_h                                0.0000
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  54,809
+  Estimated meadow area:        548.09 ha
+  Total valid pixels:           2,093,438
+  Meadow coverage:              2.62%
+
+PIPELINE RUNTIME
+  Total time: 10m 24s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Sixes_River_log.txt
+++ b/GEE/TIF_Output/Logs/Sixes_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Sixes_River
+Date/Time: 2026-04-29 16:39:02
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9831
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9900
+  Accuracy:                0.9512
+
+  Wetland:
+    Precision:             0.8355
+    Recall:                0.9416
+    F1-score:              0.8854
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9849
+    Recall:                0.9536
+    F1-score:              0.9690
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,073               927
+  Actual Wetland                 292             4,708
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_5x5_std_dev                    0.3776
+   2. tri                                 0.2276
+   3. elev_std_9x9                        0.0483
+   4. dd_v                                0.0360
+   5. curvature_plan                      0.0309
+   6. elev_std_3x3                        0.0290
+   7. soil_ksat_0_5cm                     0.0250
+   8. tpi_21x21                           0.0229
+   9. slope                               0.0180
+  10. twi_100m                            0.0159
+  11. soil_clay_pct_15_30cm               0.0150
+  12. soil_ksat_5_15cm                    0.0129
+  13. slope_5x5_std_dev                   0.0120
+  14. tpi_11x11                           0.0114
+  15. soil_clay_pct_5_15cm                0.0113
+  16. dd_h                                0.0109
+  17. soil_organic_matter_15_30cm         0.0103
+  18. dd_s                                0.0099
+  19. soil_ksat_15_30cm                   0.0096
+  20. slope_std_9x9                       0.0092
+  21. soil_clay_pct_0_5cm                 0.0090
+  22. soil_organic_matter_0_5cm           0.0083
+  23. twi_10m                             0.0079
+  24. aspect                              0.0072
+  25. elev_5x5_rel                        0.0068
+  26. soil_organic_matter_5_15cm          0.0067
+  27. tpi_3x3                             0.0052
+  28. curvature_profile                   0.0051
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  206,531
+  Estimated meadow area:        2,065.31 ha
+  Total valid pixels:           3,497,485
+  Meadow coverage:              5.91%
+
+PIPELINE RUNTIME
+  Total time: 11m 17s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Smith_River_log.txt
+++ b/GEE/TIF_Output/Logs/Smith_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Smith_River
+Date/Time: 2026-04-29 16:39:02
+================================================================================
+
+DATA SUMMARY
+  Total samples:           99,335
+  Wetland (1):             19,867  (20.0%)
+  Non-wetland (0):         79,468  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            74,501
+  Test set:                24,834
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9828
+  colsample_bytree          1.0
+  gamma                     0.1
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              100
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                1
+  scale_pos_weight          4.0001
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9943
+  Accuracy:                0.9669
+
+  Wetland:
+    Precision:             0.8770
+    Recall:                0.9708
+    F1-score:              0.9215
+    Support:               4,967
+
+  Non-Wetland:
+    Precision:             0.9925
+    Recall:                0.9660
+    F1-score:              0.9791
+    Support:               19,867
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,191               676
+  Actual Wetland                 145             4,822
+
+FEATURE IMPORTANCES (ranked)
+   1. slope                               0.5181
+   2. dd_v                                0.0897
+   3. elev_std_9x9                        0.0539
+   4. curvature_plan                      0.0502
+   5. twi_100m                            0.0187
+   6. tpi_21x21                           0.0181
+   7. tpi_11x11                           0.0181
+   8. soil_clay_pct_15_30cm               0.0174
+   9. aspect                              0.0139
+  10. soil_organic_matter_5_15cm          0.0136
+  11. soil_organic_matter_15_30cm         0.0135
+  12. slope_5x5_std_dev                   0.0131
+  13. slope_std_9x9                       0.0130
+  14. dd_h                                0.0126
+  15. dd_s                                0.0123
+  16. soil_ksat_0_5cm                     0.0115
+  17. soil_organic_matter_0_5cm           0.0107
+  18. elev_5x5_std_dev                    0.0103
+  19. soil_ksat_15_30cm                   0.0101
+  20. twi_10m                             0.0100
+  21. soil_clay_pct_0_5cm                 0.0098
+  22. soil_ksat_5_15cm                    0.0095
+  23. curvature_profile                   0.0093
+  24. soil_clay_pct_5_15cm                0.0092
+  25. elev_5x5_rel                        0.0088
+  26. tri                                 0.0086
+  27. elev_std_3x3                        0.0080
+  28. tpi_3x3                             0.0079
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  150,684
+  Estimated meadow area:        1,506.84 ha
+  Total valid pixels:           3,560,959
+  Meadow coverage:              4.23%
+
+PIPELINE RUNTIME
+  Total time: 11m 16s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/South_Fork_Coos_River_log.txt
+++ b/GEE/TIF_Output/Logs/South_Fork_Coos_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: South_Fork_Coos_River
+Date/Time: 2026-04-29 16:39:18
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9927
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9965
+  Accuracy:                0.9764
+
+  Wetland:
+    Precision:             0.9143
+    Recall:                0.9732
+    F1-score:              0.9428
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9932
+    Recall:                0.9772
+    F1-score:              0.9851
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,544               456
+  Actual Wetland                 134             4,866
+
+FEATURE IMPORTANCES (ranked)
+   1. slope                               0.2966
+   2. tri                                 0.2901
+   3. elev_std_3x3                        0.0951
+   4. curvature_plan                      0.0512
+   5. tpi_21x21                           0.0474
+   6. dd_v                                0.0360
+   7. soil_organic_matter_15_30cm         0.0163
+   8. dd_h                                0.0147
+   9. dd_s                                0.0132
+  10. tpi_11x11                           0.0120
+  11. elev_5x5_rel                        0.0113
+  12. elev_5x5_std_dev                    0.0106
+  13. soil_organic_matter_0_5cm           0.0093
+  14. elev_std_9x9                        0.0092
+  15. soil_clay_pct_0_5cm                 0.0090
+  16. slope_std_9x9                       0.0083
+  17. soil_organic_matter_5_15cm          0.0080
+  18. soil_ksat_0_5cm                     0.0073
+  19. soil_clay_pct_5_15cm                0.0070
+  20. soil_ksat_5_15cm                    0.0069
+  21. slope_5x5_std_dev                   0.0062
+  22. soil_clay_pct_15_30cm               0.0059
+  23. twi_100m                            0.0056
+  24. soil_ksat_15_30cm                   0.0052
+  25. aspect                              0.0050
+  26. tpi_3x3                             0.0047
+  27. twi_10m                             0.0040
+  28. curvature_profile                   0.0037
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  179,432
+  Estimated meadow area:        1,794.32 ha
+  Total valid pixels:           6,491,985
+  Meadow coverage:              2.76%
+
+PIPELINE RUNTIME
+  Total time: 11m 34s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/South_Fork_Coquille_River_log.txt
+++ b/GEE/TIF_Output/Logs/South_Fork_Coquille_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: South_Fork_Coquille_River
+Date/Time: 2026-04-29 16:39:12
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9687
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9781
+  Accuracy:                0.9270
+
+  Wetland:
+    Precision:             0.7574
+    Recall:                0.9342
+    F1-score:              0.8366
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9825
+    Recall:                0.9252
+    F1-score:              0.9530
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                18,504             1,496
+  Actual Wetland                 329             4,671
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.2241
+   2. elev_5x5_std_dev                    0.1781
+   3. tri                                 0.1096
+   4. dd_v                                0.0960
+   5. tpi_21x21                           0.0399
+   6. elev_std_3x3                        0.0262
+   7. soil_clay_pct_0_5cm                 0.0250
+   8. curvature_plan                      0.0219
+   9. dd_s                                0.0216
+  10. soil_organic_matter_15_30cm         0.0207
+  11. twi_100m                            0.0206
+  12. dd_h                                0.0205
+  13. soil_ksat_15_30cm                   0.0195
+  14. soil_ksat_0_5cm                     0.0177
+  15. slope                               0.0170
+  16. soil_ksat_5_15cm                    0.0145
+  17. tpi_11x11                           0.0131
+  18. slope_5x5_std_dev                   0.0126
+  19. soil_organic_matter_5_15cm          0.0120
+  20. twi_10m                             0.0115
+  21. soil_clay_pct_5_15cm                0.0109
+  22. aspect                              0.0108
+  23. elev_5x5_rel                        0.0105
+  24. slope_std_9x9                       0.0103
+  25. soil_organic_matter_0_5cm           0.0096
+  26. tpi_3x3                             0.0087
+  27. soil_clay_pct_15_30cm               0.0087
+  28. curvature_profile                   0.0084
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  575,480
+  Estimated meadow area:        5,754.80 ha
+  Total valid pixels:           7,415,871
+  Meadow coverage:              7.76%
+
+PIPELINE RUNTIME
+  Total time: 11m 33s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/South_Fork_Rogue_River_log.txt
+++ b/GEE/TIF_Output/Logs/South_Fork_Rogue_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: South_Fork_Rogue_River
+Date/Time: 2026-04-29 16:39:12
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9624
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9908
+  Accuracy:                0.9620
+
+  Wetland:
+    Precision:             0.8765
+    Recall:                0.9426
+    F1-score:              0.9084
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9854
+    Recall:                0.9668
+    F1-score:              0.9760
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,336               664
+  Actual Wetland                 287             4,713
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.2523
+   2. dd_v                                0.1458
+   3. tpi_21x21                           0.0693
+   4. elev_5x5_std_dev                    0.0550
+   5. dd_s                                0.0317
+   6. soil_clay_pct_0_5cm                 0.0291
+   7. soil_clay_pct_15_30cm               0.0287
+   8. soil_ksat_5_15cm                    0.0286
+   9. twi_100m                            0.0272
+  10. soil_ksat_15_30cm                   0.0263
+  11. soil_clay_pct_5_15cm                0.0254
+  12. dd_h                                0.0253
+  13. soil_organic_matter_5_15cm          0.0247
+  14. soil_organic_matter_15_30cm         0.0242
+  15. soil_ksat_0_5cm                     0.0233
+  16. soil_organic_matter_0_5cm           0.0225
+  17. slope_std_9x9                       0.0201
+  18. tri                                 0.0185
+  19. aspect                              0.0176
+  20. twi_10m                             0.0154
+  21. slope_5x5_std_dev                   0.0150
+  22. slope                               0.0142
+  23. curvature_profile                   0.0124
+  24. tpi_11x11                           0.0120
+  25. elev_std_3x3                        0.0102
+  26. curvature_plan                      0.0091
+  27. elev_5x5_rel                        0.0084
+  28. tpi_3x3                             0.0079
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  241,235
+  Estimated meadow area:        2,412.35 ha
+  Total valid pixels:           6,514,027
+  Meadow coverage:              3.70%
+
+PIPELINE RUNTIME
+  Total time: 11m 34s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/South_Fork_Smith_River_log.txt
+++ b/GEE/TIF_Output/Logs/South_Fork_Smith_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: South_Fork_Smith_River
+Date/Time: 2026-04-29 16:39:49
+================================================================================
+
+DATA SUMMARY
+  Total samples:           66,905
+  Wetland (1):             13,381  (20.0%)
+  Non-wetland (0):         53,524  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            50,178
+  Test set:                16,727
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9454
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          3.9998
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9614
+  Accuracy:                0.9043
+
+  Wetland:
+    Precision:             0.7027
+    Recall:                0.9037
+    F1-score:              0.7906
+    Support:               3,345
+
+  Non-Wetland:
+    Precision:             0.9741
+    Recall:                0.9044
+    F1-score:              0.9380
+    Support:               13,382
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                12,103             1,279
+  Actual Wetland                 322             3,023
+
+FEATURE IMPORTANCES (ranked)
+   1. tpi_21x21                           0.2206
+   2. twi_100m                            0.1134
+   3. dd_v                                0.0958
+   4. dd_s                                0.0454
+   5. elev_std_9x9                        0.0410
+   6. dd_h                                0.0395
+   7. aspect                              0.0297
+   8. elev_5x5_std_dev                    0.0295
+   9. tpi_11x11                           0.0263
+  10. slope_5x5_std_dev                   0.0258
+  11. twi_10m                             0.0243
+  12. soil_clay_pct_5_15cm                0.0207
+  13. curvature_profile                   0.0206
+  14. elev_std_3x3                        0.0205
+  15. slope_std_9x9                       0.0201
+  16. elev_5x5_rel                        0.0199
+  17. tri                                 0.0198
+  18. soil_clay_pct_15_30cm               0.0197
+  19. soil_organic_matter_15_30cm         0.0193
+  20. soil_clay_pct_0_5cm                 0.0188
+  21. curvature_plan                      0.0184
+  22. soil_ksat_0_5cm                     0.0171
+  23. soil_organic_matter_0_5cm           0.0168
+  24. tpi_3x3                             0.0162
+  25. soil_ksat_15_30cm                   0.0159
+  26. soil_organic_matter_5_15cm          0.0156
+  27. slope                               0.0148
+  28. soil_ksat_5_15cm                    0.0144
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  750,341
+  Estimated meadow area:        7,503.41 ha
+  Total valid pixels:           7,575,368
+  Meadow coverage:              9.91%
+
+PIPELINE RUNTIME
+  Total time: 12m 6s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Spencer_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Spencer_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Spencer_Creek
+Date/Time: 2026-04-29 16:38:49
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9943
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9975
+  Accuracy:                0.9811
+
+  Wetland:
+    Precision:             0.9365
+    Recall:                0.9712
+    F1-score:              0.9536
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9927
+    Recall:                0.9836
+    F1-score:              0.9881
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,671               329
+  Actual Wetland                 144             4,856
+
+FEATURE IMPORTANCES (ranked)
+   1. soil_ksat_15_30cm                   0.3775
+   2. soil_ksat_0_5cm                     0.1917
+   3. soil_ksat_5_15cm                    0.1192
+   4. elev_std_3x3                        0.0915
+   5. elev_5x5_std_dev                    0.0245
+   6. dd_v                                0.0217
+   7. slope                               0.0189
+   8. tri                                 0.0187
+   9. tpi_21x21                           0.0146
+  10. elev_std_9x9                        0.0126
+  11. soil_clay_pct_0_5cm                 0.0118
+  12. soil_organic_matter_0_5cm           0.0097
+  13. soil_organic_matter_5_15cm          0.0093
+  14. curvature_plan                      0.0091
+  15. twi_100m                            0.0075
+  16. slope_5x5_std_dev                   0.0065
+  17. slope_std_9x9                       0.0063
+  18. dd_s                                0.0057
+  19. aspect                              0.0053
+  20. dd_h                                0.0052
+  21. soil_organic_matter_15_30cm         0.0048
+  22. soil_clay_pct_5_15cm                0.0046
+  23. soil_clay_pct_15_30cm               0.0046
+  24. tpi_11x11                           0.0044
+  25. elev_5x5_rel                        0.0042
+  26. twi_10m                             0.0038
+  27. curvature_profile                   0.0034
+  28. tpi_3x3                             0.0031
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  115,633
+  Estimated meadow area:        1,156.33 ha
+  Total valid pixels:           2,199,868
+  Meadow coverage:              5.26%
+
+PIPELINE RUNTIME
+  Total time: 11m 0s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Sprague_River_log.txt
+++ b/GEE/TIF_Output/Logs/Sprague_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Sprague_River
+Date/Time: 2026-04-29 16:39:49
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9657
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          5
+  n_estimators              100
+  random_state              42
+  reg_alpha                 0.1
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9690
+  Accuracy:                0.9116
+
+  Wetland:
+    Precision:             0.7145
+    Recall:                0.9298
+    F1-score:              0.8080
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9810
+    Recall:                0.9071
+    F1-score:              0.9426
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                18,142             1,858
+  Actual Wetland                 351             4,649
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.4931
+   2. soil_clay_pct_5_15cm                0.1777
+   3. dd_v                                0.0650
+   4. soil_organic_matter_5_15cm          0.0246
+   5. soil_ksat_15_30cm                   0.0210
+   6. curvature_plan                      0.0190
+   7. elev_5x5_std_dev                    0.0168
+   8. tri                                 0.0139
+   9. tpi_21x21                           0.0134
+  10. soil_clay_pct_15_30cm               0.0126
+  11. slope                               0.0124
+  12. twi_100m                            0.0113
+  13. slope_std_9x9                       0.0099
+  14. soil_organic_matter_15_30cm         0.0098
+  15. soil_ksat_5_15cm                    0.0097
+  16. soil_clay_pct_0_5cm                 0.0088
+  17. soil_organic_matter_0_5cm           0.0088
+  18. elev_std_3x3                        0.0088
+  19. dd_h                                0.0081
+  20. soil_ksat_0_5cm                     0.0079
+  21. slope_5x5_std_dev                   0.0071
+  22. twi_10m                             0.0070
+  23. aspect                              0.0065
+  24. dd_s                                0.0062
+  25. tpi_11x11                           0.0058
+  26. curvature_profile                   0.0050
+  27. tpi_3x3                             0.0050
+  28. elev_5x5_rel                        0.0045
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  2,101,079
+  Estimated meadow area:        21,010.79 ha
+  Total valid pixels:           14,367,677
+  Meadow coverage:              14.62%
+
+PIPELINE RUNTIME
+  Total time: 12m 13s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Stair_Creek_Rogue_River_log.txt
+++ b/GEE/TIF_Output/Logs/Stair_Creek_Rogue_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Stair_Creek_Rogue_River
+Date/Time: 2026-04-29 16:38:35
+================================================================================
+
+DATA SUMMARY
+  Total samples:           7,090
+  Wetland (1):             1,418  (20.0%)
+  Non-wetland (0):         5,672  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            5,317
+  Test set:                1,773
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9978
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 6
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                1.5
+  scale_pos_weight          4.0019
+  subsample                 0.6
+
+TEST SET PERFORMANCE
+  AUC:                     0.9978
+  Accuracy:                0.9831
+
+  Wetland:
+    Precision:             0.9452
+    Recall:                0.9718
+    F1-score:              0.9583
+    Support:               355
+
+  Non-Wetland:
+    Precision:             0.9929
+    Recall:                0.9859
+    F1-score:              0.9894
+    Support:               1,418
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 1,398                20
+  Actual Wetland                  10               345
+
+FEATURE IMPORTANCES (ranked)
+   1. tpi_21x21                           0.1075
+   2. tri                                 0.0968
+   3. soil_organic_matter_15_30cm         0.0720
+   4. twi_10m                             0.0592
+   5. elev_5x5_std_dev                    0.0543
+   6. soil_clay_pct_0_5cm                 0.0543
+   7. soil_organic_matter_5_15cm          0.0526
+   8. elev_std_3x3                        0.0466
+   9. soil_clay_pct_5_15cm                0.0439
+  10. soil_clay_pct_15_30cm               0.0369
+  11. soil_ksat_0_5cm                     0.0365
+  12. twi_100m                            0.0348
+  13. soil_organic_matter_0_5cm           0.0321
+  14. elev_std_9x9                        0.0294
+  15. curvature_plan                      0.0292
+  16. aspect                              0.0271
+  17. dd_v                                0.0265
+  18. slope                               0.0221
+  19. soil_ksat_15_30cm                   0.0190
+  20. dd_s                                0.0180
+  21. dd_h                                0.0164
+  22. slope_5x5_std_dev                   0.0154
+  23. tpi_11x11                           0.0150
+  24. slope_std_9x9                       0.0133
+  25. soil_ksat_5_15cm                    0.0126
+  26. elev_5x5_rel                        0.0125
+  27. tpi_3x3                             0.0093
+  28. curvature_profile                   0.0068
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  28,861
+  Estimated meadow area:        288.61 ha
+  Total valid pixels:           1,482,311
+  Meadow coverage:              1.95%
+
+PIPELINE RUNTIME
+  Total time: 10m 44s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Steamboat_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Steamboat_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Steamboat_Creek
+Date/Time: 2026-04-29 16:38:58
+================================================================================
+
+DATA SUMMARY
+  Total samples:           49,700
+  Wetland (1):             9,940  (20.0%)
+  Non-wetland (0):         39,760  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            37,275
+  Test set:                12,425
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9765
+  colsample_bytree          1.0
+  gamma                     0.5
+  learning_rate             0.1
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                1.5
+  scale_pos_weight          4.0
+  subsample                 0.6
+
+TEST SET PERFORMANCE
+  AUC:                     0.9933
+  Accuracy:                0.9631
+
+  Wetland:
+    Precision:             0.8780
+    Recall:                0.9469
+    F1-score:              0.9111
+    Support:               2,485
+
+  Non-Wetland:
+    Precision:             0.9865
+    Recall:                0.9671
+    F1-score:              0.9767
+    Support:               9,940
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 9,613               327
+  Actual Wetland                 132             2,353
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_5x5_std_dev                    0.2981
+   2. soil_clay_pct_0_5cm                 0.0964
+   3. tpi_21x21                           0.0864
+   4. elev_std_9x9                        0.0743
+   5. soil_ksat_15_30cm                   0.0311
+   6. tpi_11x11                           0.0280
+   7. slope                               0.0264
+   8. twi_100m                            0.0261
+   9. dd_v                                0.0253
+  10. aspect                              0.0237
+  11. dd_s                                0.0209
+  12. soil_organic_matter_0_5cm           0.0198
+  13. twi_10m                             0.0195
+  14. dd_h                                0.0190
+  15. soil_organic_matter_5_15cm          0.0182
+  16. slope_std_9x9                       0.0178
+  17. soil_ksat_0_5cm                     0.0172
+  18. soil_organic_matter_15_30cm         0.0171
+  19. tri                                 0.0170
+  20. soil_clay_pct_15_30cm               0.0157
+  21. soil_clay_pct_5_15cm                0.0150
+  22. slope_5x5_std_dev                   0.0136
+  23. soil_ksat_5_15cm                    0.0135
+  24. curvature_profile                   0.0133
+  25. elev_std_3x3                        0.0131
+  26. curvature_plan                      0.0123
+  27. elev_5x5_rel                        0.0111
+  28. tpi_3x3                             0.0103
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  131,969
+  Estimated meadow area:        1,319.69 ha
+  Total valid pixels:           4,248,018
+  Meadow coverage:              3.11%
+
+PIPELINE RUNTIME
+  Total time: 11m 11s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Sucker_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Sucker_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Sucker_Creek
+Date/Time: 2026-04-29 16:39:00
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9536
+  colsample_bytree          0.6
+  gamma                     0.1
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          5
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.6
+
+TEST SET PERFORMANCE
+  AUC:                     0.9707
+  Accuracy:                0.9144
+
+  Wetland:
+    Precision:             0.7249
+    Recall:                0.9214
+    F1-score:              0.8114
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9789
+    Recall:                0.9126
+    F1-score:              0.9446
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                18,252             1,748
+  Actual Wetland                 393             4,607
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.1989
+   2. tpi_21x21                           0.1529
+   3. slope                               0.0426
+   4. elev_5x5_std_dev                    0.0381
+   5. elev_std_3x3                        0.0364
+   6. tpi_11x11                           0.0350
+   7. elev_std_9x9                        0.0323
+   8. aspect                              0.0314
+   9. soil_clay_pct_15_30cm               0.0294
+  10. soil_organic_matter_15_30cm         0.0293
+  11. twi_100m                            0.0287
+  12. twi_10m                             0.0274
+  13. elev_5x5_rel                        0.0260
+  14. dd_h                                0.0252
+  15. dd_s                                0.0245
+  16. slope_5x5_std_dev                   0.0242
+  17. soil_clay_pct_0_5cm                 0.0217
+  18. tri                                 0.0210
+  19. slope_std_9x9                       0.0208
+  20. soil_clay_pct_5_15cm                0.0207
+  21. soil_organic_matter_0_5cm           0.0203
+  22. soil_organic_matter_5_15cm          0.0189
+  23. soil_ksat_15_30cm                   0.0177
+  24. curvature_plan                      0.0170
+  25. tpi_3x3                             0.0169
+  26. soil_ksat_5_15cm                    0.0157
+  27. soil_ksat_0_5cm                     0.0146
+  28. curvature_profile                   0.0124
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  249,810
+  Estimated meadow area:        2,498.10 ha
+  Total valid pixels:           2,495,136
+  Meadow coverage:              10.01%
+
+PIPELINE RUNTIME
+  Total time: 11m 11s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Swan_Lake_Valley_log.txt
+++ b/GEE/TIF_Output/Logs/Swan_Lake_Valley_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Swan_Lake_Valley
+Date/Time: 2026-04-29 16:39:09
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9869
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9917
+  Accuracy:                0.9665
+
+  Wetland:
+    Precision:             0.8870
+    Recall:                0.9542
+    F1-score:              0.9194
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9883
+    Recall:                0.9696
+    F1-score:              0.9789
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,392               608
+  Actual Wetland                 229             4,771
+
+FEATURE IMPORTANCES (ranked)
+   1. soil_ksat_5_15cm                    0.3323
+   2. soil_ksat_0_5cm                     0.1705
+   3. soil_organic_matter_15_30cm         0.0672
+   4. elev_std_9x9                        0.0658
+   5. soil_ksat_15_30cm                   0.0540
+   6. tri                                 0.0521
+   7. soil_organic_matter_5_15cm          0.0442
+   8. soil_organic_matter_0_5cm           0.0326
+   9. elev_5x5_std_dev                    0.0235
+  10. soil_clay_pct_15_30cm               0.0181
+  11. soil_clay_pct_0_5cm                 0.0167
+  12. slope                               0.0137
+  13. elev_std_3x3                        0.0129
+  14. soil_clay_pct_5_15cm                0.0117
+  15. twi_100m                            0.0086
+  16. tpi_21x21                           0.0082
+  17. dd_s                                0.0076
+  18. twi_10m                             0.0074
+  19. dd_h                                0.0073
+  20. dd_v                                0.0065
+  21. aspect                              0.0063
+  22. tpi_11x11                           0.0062
+  23. slope_std_9x9                       0.0052
+  24. curvature_plan                      0.0050
+  25. slope_5x5_std_dev                   0.0047
+  26. elev_5x5_rel                        0.0043
+  27. tpi_3x3                             0.0037
+  28. curvature_profile                   0.0036
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  357,165
+  Estimated meadow area:        3,571.65 ha
+  Total valid pixels:           3,368,652
+  Meadow coverage:              10.60%
+
+PIPELINE RUNTIME
+  Total time: 11m 24s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Thompson_Creek_Klamath_River_log.txt
+++ b/GEE/TIF_Output/Logs/Thompson_Creek_Klamath_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Thompson_Creek_Klamath_River
+Date/Time: 2026-04-29 16:38:49
+================================================================================
+
+DATA SUMMARY
+  Total samples:           18,335
+  Wetland (1):             3,667  (20.0%)
+  Non-wetland (0):         14,668  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            13,751
+  Test set:                4,584
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9872
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0004
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9937
+  Accuracy:                0.9666
+
+  Wetland:
+    Precision:             0.8874
+    Recall:                0.9542
+    F1-score:              0.9196
+    Support:               917
+
+  Non-Wetland:
+    Precision:             0.9883
+    Recall:                0.9697
+    F1-score:              0.9789
+    Support:               3,667
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 3,556               111
+  Actual Wetland                  42               875
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.3882
+   2. tpi_21x21                           0.0979
+   3. elev_std_9x9                        0.0585
+   4. twi_100m                            0.0481
+   5. slope_std_9x9                       0.0338
+   6. dd_s                                0.0306
+   7. aspect                              0.0297
+   8. dd_h                                0.0259
+   9. slope                               0.0242
+  10. elev_5x5_std_dev                    0.0238
+  11. soil_ksat_15_30cm                   0.0234
+  12. soil_clay_pct_15_30cm               0.0227
+  13. soil_organic_matter_0_5cm           0.0224
+  14. soil_clay_pct_0_5cm                 0.0181
+  15. soil_ksat_0_5cm                     0.0161
+  16. twi_10m                             0.0140
+  17. tpi_11x11                           0.0137
+  18. soil_organic_matter_5_15cm          0.0132
+  19. soil_ksat_5_15cm                    0.0130
+  20. slope_5x5_std_dev                   0.0117
+  21. elev_std_3x3                        0.0104
+  22. elev_5x5_rel                        0.0104
+  23. tri                                 0.0102
+  24. soil_clay_pct_5_15cm                0.0096
+  25. curvature_profile                   0.0089
+  26. soil_organic_matter_15_30cm         0.0086
+  27. curvature_plan                      0.0075
+  28. tpi_3x3                             0.0054
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  99,229
+  Estimated meadow area:        992.29 ha
+  Total valid pixels:           2,727,844
+  Meadow coverage:              3.64%
+
+PIPELINE RUNTIME
+  Total time: 11m 0s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Trail_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Trail_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Trail_Creek
+Date/Time: 2026-04-29 16:38:35
+================================================================================
+
+DATA SUMMARY
+  Total samples:           5,340
+  Wetland (1):             1,068  (20.0%)
+  Non-wetland (0):         4,272  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            4,005
+  Test set:                1,335
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9925
+  colsample_bytree          1.0
+  gamma                     0.1
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              100
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                1
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9910
+  Accuracy:                0.9603
+
+  Wetland:
+    Precision:             0.8639
+    Recall:                0.9513
+    F1-score:              0.9055
+    Support:               267
+
+  Non-Wetland:
+    Precision:             0.9875
+    Recall:                0.9625
+    F1-score:              0.9749
+    Support:               1,068
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 1,028                40
+  Actual Wetland                  13               254
+
+FEATURE IMPORTANCES (ranked)
+   1. tpi_21x21                           0.2057
+   2. dd_v                                0.1220
+   3. dd_h                                0.0514
+   4. elev_std_9x9                        0.0499
+   5. twi_100m                            0.0432
+   6. slope_std_9x9                       0.0347
+   7. soil_ksat_0_5cm                     0.0336
+   8. twi_10m                             0.0320
+   9. aspect                              0.0300
+  10. soil_ksat_15_30cm                   0.0298
+  11. dd_s                                0.0289
+  12. soil_organic_matter_15_30cm         0.0266
+  13. elev_5x5_std_dev                    0.0246
+  14. soil_clay_pct_5_15cm                0.0238
+  15. soil_clay_pct_0_5cm                 0.0234
+  16. soil_ksat_5_15cm                    0.0234
+  17. tpi_11x11                           0.0230
+  18. soil_organic_matter_5_15cm          0.0219
+  19. curvature_profile                   0.0211
+  20. elev_5x5_rel                        0.0209
+  21. elev_std_3x3                        0.0209
+  22. soil_organic_matter_0_5cm           0.0204
+  23. tpi_3x3                             0.0174
+  24. slope                               0.0173
+  25. slope_5x5_std_dev                   0.0144
+  26. soil_clay_pct_15_30cm               0.0142
+  27. tri                                 0.0140
+  28. curvature_plan                      0.0114
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  46,383
+  Estimated meadow area:        463.83 ha
+  Total valid pixels:           1,433,569
+  Meadow coverage:              3.24%
+
+PIPELINE RUNTIME
+  Total time: 10m 44s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Ukonom_Creek_Klamath_River_log.txt
+++ b/GEE/TIF_Output/Logs/Ukonom_Creek_Klamath_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Ukonom_Creek_Klamath_River
+Date/Time: 2026-04-29 16:38:49
+================================================================================
+
+DATA SUMMARY
+  Total samples:           29,350
+  Wetland (1):             5,870  (20.0%)
+  Non-wetland (0):         23,480  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            22,012
+  Test set:                7,338
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9803
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0005
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9877
+  Accuracy:                0.9554
+
+  Wetland:
+    Precision:             0.8506
+    Recall:                0.9428
+    F1-score:              0.8943
+    Support:               1,468
+
+  Non-Wetland:
+    Precision:             0.9853
+    Recall:                0.9586
+    F1-score:              0.9718
+    Support:               5,870
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 5,627               243
+  Actual Wetland                  84             1,384
+
+FEATURE IMPORTANCES (ranked)
+   1. tpi_21x21                           0.2733
+   2. dd_v                                0.1451
+   3. elev_std_9x9                        0.1109
+   4. slope_std_9x9                       0.0637
+   5. soil_clay_pct_0_5cm                 0.0328
+   6. dd_s                                0.0283
+   7. curvature_plan                      0.0254
+   8. aspect                              0.0251
+   9. soil_organic_matter_0_5cm           0.0233
+  10. dd_h                                0.0230
+  11. curvature_profile                   0.0208
+  12. twi_100m                            0.0203
+  13. elev_5x5_rel                        0.0197
+  14. slope                               0.0174
+  15. tpi_11x11                           0.0168
+  16. twi_10m                             0.0164
+  17. soil_ksat_15_30cm                   0.0164
+  18. soil_ksat_0_5cm                     0.0134
+  19. tri                                 0.0131
+  20. soil_clay_pct_15_30cm               0.0118
+  21. soil_organic_matter_15_30cm         0.0115
+  22. soil_ksat_5_15cm                    0.0114
+  23. soil_clay_pct_5_15cm                0.0114
+  24. soil_organic_matter_5_15cm          0.0101
+  25. slope_5x5_std_dev                   0.0101
+  26. elev_5x5_std_dev                    0.0099
+  27. elev_std_3x3                        0.0095
+  28. tpi_3x3                             0.0087
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  154,625
+  Estimated meadow area:        1,546.25 ha
+  Total valid pixels:           3,565,833
+  Meadow coverage:              4.34%
+
+PIPELINE RUNTIME
+  Total time: 11m 2s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Upper_Applegate_River_log.txt
+++ b/GEE/TIF_Output/Logs/Upper_Applegate_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Upper_Applegate_River
+Date/Time: 2026-04-29 16:38:44
+================================================================================
+
+DATA SUMMARY
+  Total samples:           17,885
+  Wetland (1):             3,577  (20.0%)
+  Non-wetland (0):         14,308  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            13,413
+  Test set:                4,472
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9886
+  colsample_bytree          1.0
+  gamma                     0.5
+  learning_rate             0.1
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                1.5
+  scale_pos_weight          3.9993
+  subsample                 0.6
+
+TEST SET PERFORMANCE
+  AUC:                     0.9904
+  Accuracy:                0.9591
+
+  Wetland:
+    Precision:             0.8496
+    Recall:                0.9664
+    F1-score:              0.9042
+    Support:               894
+
+  Non-Wetland:
+    Precision:             0.9913
+    Recall:                0.9572
+    F1-score:              0.9740
+    Support:               3,578
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 3,425               153
+  Actual Wetland                  30               864
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.5463
+   2. elev_std_9x9                        0.0536
+   3. tpi_21x21                           0.0496
+   4. slope_5x5_std_dev                   0.0450
+   5. slope_std_9x9                       0.0353
+   6. curvature_plan                      0.0298
+   7. elev_5x5_std_dev                    0.0173
+   8. tpi_11x11                           0.0168
+   9. twi_10m                             0.0144
+  10. aspect                              0.0127
+  11. twi_100m                            0.0123
+  12. dd_s                                0.0121
+  13. tpi_3x3                             0.0113
+  14. soil_ksat_0_5cm                     0.0113
+  15. slope                               0.0110
+  16. soil_clay_pct_0_5cm                 0.0109
+  17. soil_organic_matter_0_5cm           0.0103
+  18. soil_organic_matter_5_15cm          0.0101
+  19. soil_clay_pct_15_30cm               0.0098
+  20. tri                                 0.0097
+  21. elev_5x5_rel                        0.0096
+  22. soil_clay_pct_5_15cm                0.0096
+  23. soil_organic_matter_15_30cm         0.0096
+  24. elev_std_3x3                        0.0085
+  25. curvature_profile                   0.0084
+  26. soil_ksat_15_30cm                   0.0082
+  27. soil_ksat_5_15cm                    0.0082
+  28. dd_h                                0.0081
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  82,939
+  Estimated meadow area:        829.39 ha
+  Total valid pixels:           2,120,377
+  Meadow coverage:              3.91%
+
+PIPELINE RUNTIME
+  Total time: 10m 54s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Upper_Cow_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Upper_Cow_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Upper_Cow_Creek
+Date/Time: 2026-04-29 16:38:44
+================================================================================
+
+DATA SUMMARY
+  Total samples:           34,275
+  Wetland (1):             6,855  (20.0%)
+  Non-wetland (0):         27,420  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            25,706
+  Test set:                8,569
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9863
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0002
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9947
+  Accuracy:                0.9704
+
+  Wetland:
+    Precision:             0.8925
+    Recall:                0.9685
+    F1-score:              0.9289
+    Support:               1,714
+
+  Non-Wetland:
+    Precision:             0.9920
+    Recall:                0.9708
+    F1-score:              0.9813
+    Support:               6,855
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 6,655               200
+  Actual Wetland                  54             1,660
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.3655
+   2. dd_v                                0.1091
+   3. elev_5x5_std_dev                    0.1087
+   4. tpi_21x21                           0.0784
+   5. soil_organic_matter_0_5cm           0.0360
+   6. soil_organic_matter_5_15cm          0.0228
+   7. twi_100m                            0.0225
+   8. slope_std_9x9                       0.0208
+   9. dd_s                                0.0193
+  10. soil_ksat_15_30cm                   0.0183
+  11. soil_organic_matter_15_30cm         0.0163
+  12. elev_std_3x3                        0.0149
+  13. aspect                              0.0143
+  14. tri                                 0.0132
+  15. dd_h                                0.0126
+  16. soil_ksat_5_15cm                    0.0126
+  17. slope_5x5_std_dev                   0.0124
+  18. soil_ksat_0_5cm                     0.0121
+  19. soil_clay_pct_15_30cm               0.0117
+  20. soil_clay_pct_0_5cm                 0.0115
+  21. slope                               0.0109
+  22. soil_clay_pct_5_15cm                0.0108
+  23. twi_10m                             0.0101
+  24. tpi_11x11                           0.0087
+  25. curvature_plan                      0.0076
+  26. elev_5x5_rel                        0.0074
+  27. curvature_profile                   0.0065
+  28. tpi_3x3                             0.0052
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  58,128
+  Estimated meadow area:        581.28 ha
+  Total valid pixels:           1,926,744
+  Meadow coverage:              3.02%
+
+PIPELINE RUNTIME
+  Total time: 10m 55s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Upper_Little_Deschutes_River_log.txt
+++ b/GEE/TIF_Output/Logs/Upper_Little_Deschutes_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Upper_Little_Deschutes_River
+Date/Time: 2026-04-29 16:39:01
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9758
+  colsample_bytree          0.6
+  gamma                     0.5
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          1
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9853
+  Accuracy:                0.9453
+
+  Wetland:
+    Precision:             0.8123
+    Recall:                0.9450
+    F1-score:              0.8736
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9857
+    Recall:                0.9454
+    F1-score:              0.9651
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                18,908             1,092
+  Actual Wetland                 275             4,725
+
+FEATURE IMPORTANCES (ranked)
+   1. soil_clay_pct_0_5cm                 0.1895
+   2. soil_clay_pct_5_15cm                0.1022
+   3. twi_100m                            0.0692
+   4. tpi_21x21                           0.0692
+   5. elev_std_9x9                        0.0665
+   6. elev_5x5_std_dev                    0.0529
+   7. dd_h                                0.0500
+   8. soil_ksat_15_30cm                   0.0450
+   9. dd_v                                0.0320
+  10. dd_s                                0.0289
+  11. soil_ksat_5_15cm                    0.0288
+  12. soil_organic_matter_5_15cm          0.0235
+  13. slope_5x5_std_dev                   0.0229
+  14. tri                                 0.0209
+  15. soil_clay_pct_15_30cm               0.0193
+  16. slope_std_9x9                       0.0180
+  17. slope                               0.0179
+  18. tpi_11x11                           0.0158
+  19. curvature_plan                      0.0157
+  20. elev_std_3x3                        0.0153
+  21. soil_organic_matter_15_30cm         0.0151
+  22. soil_ksat_0_5cm                     0.0146
+  23. soil_organic_matter_0_5cm           0.0145
+  24. aspect                              0.0134
+  25. twi_10m                             0.0126
+  26. elev_5x5_rel                        0.0114
+  27. tpi_3x3                             0.0084
+  28. curvature_profile                   0.0065
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  261,856
+  Estimated meadow area:        2,618.56 ha
+  Total valid pixels:           3,210,091
+  Meadow coverage:              8.16%
+
+PIPELINE RUNTIME
+  Total time: 11m 12s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Upper_North_Umpqua_River_log.txt
+++ b/GEE/TIF_Output/Logs/Upper_North_Umpqua_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Upper_North_Umpqua_River
+Date/Time: 2026-04-29 16:38:58
+================================================================================
+
+DATA SUMMARY
+  Total samples:           20,835
+  Wetland (1):             4,167  (20.0%)
+  Non-wetland (0):         16,668  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            15,626
+  Test set:                5,209
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9854
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0003
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9932
+  Accuracy:                0.9683
+
+  Wetland:
+    Precision:             0.8968
+    Recall:                0.9511
+    F1-score:              0.9231
+    Support:               1,042
+
+  Non-Wetland:
+    Precision:             0.9876
+    Recall:                0.9726
+    F1-score:              0.9801
+    Support:               4,167
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 4,053               114
+  Actual Wetland                  51               991
+
+FEATURE IMPORTANCES (ranked)
+   1. tpi_11x11                           0.1278
+   2. tpi_21x21                           0.0912
+   3. elev_5x5_std_dev                    0.0705
+   4. dd_v                                0.0689
+   5. soil_ksat_15_30cm                   0.0536
+   6. elev_std_9x9                        0.0472
+   7. aspect                              0.0469
+   8. tri                                 0.0444
+   9. twi_10m                             0.0352
+  10. soil_clay_pct_15_30cm               0.0349
+  11. soil_organic_matter_0_5cm           0.0347
+  12. soil_ksat_5_15cm                    0.0336
+  13. elev_std_3x3                        0.0304
+  14. soil_clay_pct_5_15cm                0.0301
+  15. soil_clay_pct_0_5cm                 0.0291
+  16. twi_100m                            0.0286
+  17. soil_organic_matter_5_15cm          0.0257
+  18. dd_s                                0.0227
+  19. slope                               0.0217
+  20. soil_ksat_0_5cm                     0.0208
+  21. dd_h                                0.0207
+  22. slope_std_9x9                       0.0195
+  23. soil_organic_matter_15_30cm         0.0193
+  24. slope_5x5_std_dev                   0.0108
+  25. curvature_profile                   0.0095
+  26. elev_5x5_rel                        0.0082
+  27. curvature_plan                      0.0080
+  28. tpi_3x3                             0.0060
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  72,220
+  Estimated meadow area:        722.20 ha
+  Total valid pixels:           2,636,269
+  Meadow coverage:              2.74%
+
+PIPELINE RUNTIME
+  Total time: 11m 8s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Upper_South_Umpqua_River_log.txt
+++ b/GEE/TIF_Output/Logs/Upper_South_Umpqua_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Upper_South_Umpqua_River
+Date/Time: 2026-04-29 16:39:01
+================================================================================
+
+DATA SUMMARY
+  Total samples:           38,335
+  Wetland (1):             7,667  (20.0%)
+  Non-wetland (0):         30,668  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            28,751
+  Test set:                9,584
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9708
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0002
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9903
+  Accuracy:                0.9589
+
+  Wetland:
+    Precision:             0.8709
+    Recall:                0.9327
+    F1-score:              0.9008
+    Support:               1,917
+
+  Non-Wetland:
+    Precision:             0.9829
+    Recall:                0.9654
+    F1-score:              0.9741
+    Support:               7,667
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 7,402               265
+  Actual Wetland                 129             1,788
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.2507
+   2. tpi_21x21                           0.1277
+   3. dd_v                                0.0525
+   4. soil_clay_pct_0_5cm                 0.0432
+   5. soil_clay_pct_5_15cm                0.0396
+   6. soil_ksat_15_30cm                   0.0375
+   7. soil_ksat_5_15cm                    0.0348
+   8. dd_s                                0.0337
+   9. soil_clay_pct_15_30cm               0.0313
+  10. dd_h                                0.0297
+  11. twi_100m                            0.0294
+  12. aspect                              0.0254
+  13. soil_organic_matter_15_30cm         0.0253
+  14. soil_organic_matter_0_5cm           0.0215
+  15. twi_10m                             0.0214
+  16. tri                                 0.0201
+  17. slope_std_9x9                       0.0185
+  18. slope_5x5_std_dev                   0.0172
+  19. soil_ksat_0_5cm                     0.0167
+  20. elev_5x5_std_dev                    0.0166
+  21. slope                               0.0157
+  22. curvature_profile                   0.0152
+  23. tpi_11x11                           0.0151
+  24. soil_organic_matter_5_15cm          0.0146
+  25. elev_5x5_rel                        0.0131
+  26. elev_std_3x3                        0.0130
+  27. curvature_plan                      0.0112
+  28. tpi_3x3                             0.0090
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  122,319
+  Estimated meadow area:        1,223.19 ha
+  Total valid pixels:           3,536,069
+  Meadow coverage:              3.46%
+
+PIPELINE RUNTIME
+  Total time: 11m 12s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Upper_Umpqua_River_log.txt
+++ b/GEE/TIF_Output/Logs/Upper_Umpqua_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Upper_Umpqua_River
+Date/Time: 2026-04-29 16:39:10
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9625
+  colsample_bytree          0.6
+  gamma                     0.1
+  learning_rate             0.05
+  max_depth                 8
+  min_child_weight          5
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 0.6
+
+TEST SET PERFORMANCE
+  AUC:                     0.9749
+  Accuracy:                0.9147
+
+  Wetland:
+    Precision:             0.7220
+    Recall:                0.9328
+    F1-score:              0.8140
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9819
+    Recall:                0.9102
+    F1-score:              0.9447
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                18,204             1,796
+  Actual Wetland                 336             4,664
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.2014
+   2. slope                               0.1826
+   3. elev_5x5_std_dev                    0.0986
+   4. tri                                 0.0512
+   5. tpi_21x21                           0.0496
+   6. elev_std_3x3                        0.0462
+   7. dd_v                                0.0388
+   8. curvature_plan                      0.0302
+   9. soil_ksat_5_15cm                    0.0295
+  10. tpi_11x11                           0.0249
+  11. soil_ksat_0_5cm                     0.0179
+  12. elev_5x5_rel                        0.0175
+  13. soil_clay_pct_0_5cm                 0.0148
+  14. soil_ksat_15_30cm                   0.0146
+  15. slope_5x5_std_dev                   0.0143
+  16. soil_clay_pct_15_30cm               0.0143
+  17. slope_std_9x9                       0.0141
+  18. twi_100m                            0.0140
+  19. tpi_3x3                             0.0135
+  20. soil_clay_pct_5_15cm                0.0132
+  21. soil_organic_matter_15_30cm         0.0130
+  22. soil_organic_matter_5_15cm          0.0130
+  23. soil_organic_matter_0_5cm           0.0129
+  24. aspect                              0.0128
+  25. dd_s                                0.0124
+  26. dd_h                                0.0118
+  27. twi_10m                             0.0118
+  28. curvature_profile                   0.0113
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  649,573
+  Estimated meadow area:        6,495.73 ha
+  Total valid pixels:           6,883,965
+  Meadow coverage:              9.44%
+
+PIPELINE RUNTIME
+  Total time: 11m 32s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/West_Fork_Cow_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/West_Fork_Cow_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: West_Fork_Cow_Creek
+Date/Time: 2026-04-29 16:37:21
+================================================================================
+
+DATA SUMMARY
+  Total samples:           15,070
+  Wetland (1):             3,014  (20.0%)
+  Non-wetland (0):         12,056  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            11,302
+  Test set:                3,768
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9889
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0009
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9923
+  Accuracy:                0.9639
+
+  Wetland:
+    Precision:             0.8972
+    Recall:                0.9257
+    F1-score:              0.9112
+    Support:               754
+
+  Non-Wetland:
+    Precision:             0.9813
+    Recall:                0.9735
+    F1-score:              0.9773
+    Support:               3,014
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 2,934                80
+  Actual Wetland                  56               698
+
+FEATURE IMPORTANCES (ranked)
+   1. tpi_21x21                           0.2246
+   2. elev_std_9x9                        0.1252
+   3. slope                               0.0973
+   4. slope_5x5_std_dev                   0.0838
+   5. elev_5x5_std_dev                    0.0558
+   6. soil_ksat_0_5cm                     0.0357
+   7. soil_clay_pct_5_15cm                0.0351
+   8. slope_std_9x9                       0.0275
+   9. dd_h                                0.0257
+  10. soil_clay_pct_15_30cm               0.0250
+  11. soil_clay_pct_0_5cm                 0.0241
+  12. twi_100m                            0.0235
+  13. dd_v                                0.0213
+  14. dd_s                                0.0204
+  15. soil_organic_matter_0_5cm           0.0187
+  16. soil_organic_matter_15_30cm         0.0178
+  17. aspect                              0.0167
+  18. soil_ksat_5_15cm                    0.0163
+  19. soil_ksat_15_30cm                   0.0152
+  20. soil_organic_matter_5_15cm          0.0149
+  21. twi_10m                             0.0133
+  22. tri                                 0.0126
+  23. tpi_11x11                           0.0122
+  24. curvature_profile                   0.0092
+  25. elev_std_3x3                        0.0082
+  26. elev_5x5_rel                        0.0073
+  27. curvature_plan                      0.0073
+  28. tpi_3x3                             0.0055
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  77,549
+  Estimated meadow area:        775.49 ha
+  Total valid pixels:           2,267,688
+  Meadow coverage:              3.42%
+
+PIPELINE RUNTIME
+  Total time: 9m 30s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/West_Fork_Illinois_River_log.txt
+++ b/GEE/TIF_Output/Logs/West_Fork_Illinois_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: West_Fork_Illinois_River
+Date/Time: 2026-04-29 16:37:21
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9709
+  colsample_bytree          0.6
+  gamma                     0
+  learning_rate             0.1
+  max_depth                 8
+  min_child_weight          5
+  n_estimators              200
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                1.5
+  scale_pos_weight          4.0
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9870
+  Accuracy:                0.9450
+
+  Wetland:
+    Precision:             0.8082
+    Recall:                0.9508
+    F1-score:              0.8737
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9871
+    Recall:                0.9436
+    F1-score:              0.9649
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                18,872             1,128
+  Actual Wetland                 246             4,754
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.2871
+   2. twi_100m                            0.0669
+   3. elev_5x5_std_dev                    0.0576
+   4. soil_ksat_0_5cm                     0.0430
+   5. soil_organic_matter_0_5cm           0.0408
+   6. soil_clay_pct_5_15cm                0.0405
+   7. soil_clay_pct_0_5cm                 0.0371
+   8. slope                               0.0367
+   9. elev_std_9x9                        0.0332
+  10. tpi_21x21                           0.0310
+  11. soil_clay_pct_15_30cm               0.0294
+  12. soil_organic_matter_15_30cm         0.0289
+  13. dd_h                                0.0287
+  14. soil_ksat_5_15cm                    0.0260
+  15. slope_std_9x9                       0.0238
+  16. dd_s                                0.0223
+  17. soil_ksat_15_30cm                   0.0215
+  18. soil_organic_matter_5_15cm          0.0201
+  19. tri                                 0.0182
+  20. aspect                              0.0174
+  21. slope_5x5_std_dev                   0.0166
+  22. tpi_11x11                           0.0124
+  23. elev_std_3x3                        0.0123
+  24. twi_10m                             0.0114
+  25. elev_5x5_rel                        0.0114
+  26. curvature_profile                   0.0096
+  27. curvature_plan                      0.0086
+  28. tpi_3x3                             0.0075
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  187,875
+  Estimated meadow area:        1,878.75 ha
+  Total valid pixels:           3,121,454
+  Meadow coverage:              6.02%
+
+PIPELINE RUNTIME
+  Total time: 9m 31s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Whalehead_Creek_Frontal_Cape_Ferrelo_log.txt
+++ b/GEE/TIF_Output/Logs/Whalehead_Creek_Frontal_Cape_Ferrelo_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Whalehead_Creek_Frontal_Cape_Ferrelo
+Date/Time: 2026-04-29 16:37:21
+================================================================================
+
+DATA SUMMARY
+  Total samples:           20,910
+  Wetland (1):             4,182  (20.0%)
+  Non-wetland (0):         16,728  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            15,682
+  Test set:                5,228
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9844
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0006
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9917
+  Accuracy:                0.9640
+
+  Wetland:
+    Precision:             0.8950
+    Recall:                0.9293
+    F1-score:              0.9118
+    Support:               1,046
+
+  Non-Wetland:
+    Precision:             0.9821
+    Recall:                0.9727
+    F1-score:              0.9774
+    Support:               4,182
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 4,068               114
+  Actual Wetland                  74               972
+
+FEATURE IMPORTANCES (ranked)
+   1. slope                               0.3510
+   2. curvature_plan                      0.1038
+   3. tpi_21x21                           0.0714
+   4. elev_std_9x9                        0.0610
+   5. soil_organic_matter_0_5cm           0.0280
+   6. twi_100m                            0.0275
+   7. tpi_11x11                           0.0268
+   8. dd_v                                0.0259
+   9. dd_s                                0.0257
+  10. dd_h                                0.0238
+  11. slope_5x5_std_dev                   0.0237
+  12. soil_clay_pct_5_15cm                0.0202
+  13. soil_ksat_15_30cm                   0.0193
+  14. elev_5x5_std_dev                    0.0179
+  15. slope_std_9x9                       0.0179
+  16. soil_ksat_0_5cm                     0.0177
+  17. soil_organic_matter_5_15cm          0.0152
+  18. soil_organic_matter_15_30cm         0.0152
+  19. soil_ksat_5_15cm                    0.0144
+  20. soil_clay_pct_15_30cm               0.0143
+  21. soil_clay_pct_0_5cm                 0.0134
+  22. aspect                              0.0134
+  23. twi_10m                             0.0109
+  24. tri                                 0.0092
+  25. tpi_3x3                             0.0085
+  26. elev_5x5_rel                        0.0083
+  27. curvature_profile                   0.0080
+  28. elev_std_3x3                        0.0078
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  54,924
+  Estimated meadow area:        549.24 ha
+  Total valid pixels:           1,553,292
+  Meadow coverage:              3.54%
+
+PIPELINE RUNTIME
+  Total time: 9m 30s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Williams_Creek_log.txt
+++ b/GEE/TIF_Output/Logs/Williams_Creek_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Williams_Creek
+Date/Time: 2026-04-29 16:37:21
+================================================================================
+
+DATA SUMMARY
+  Total samples:           44,620
+  Wetland (1):             8,924  (20.0%)
+  Non-wetland (0):         35,696  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            33,465
+  Test set:                11,155
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9695
+  colsample_bytree          0.8
+  gamma                     1.0
+  learning_rate             0.1
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.1
+  reg_lambda                1.5
+  scale_pos_weight          4.0
+  subsample                 0.8
+
+TEST SET PERFORMANCE
+  AUC:                     0.9838
+  Accuracy:                0.9451
+
+  Wetland:
+    Precision:             0.8173
+    Recall:                0.9346
+    F1-score:              0.8720
+    Support:               2,231
+
+  Non-Wetland:
+    Precision:             0.9830
+    Recall:                0.9478
+    F1-score:              0.9651
+    Support:               8,924
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 8,458               466
+  Actual Wetland                 146             2,085
+
+FEATURE IMPORTANCES (ranked)
+   1. dd_v                                0.2962
+   2. tpi_21x21                           0.0812
+   3. elev_5x5_std_dev                    0.0639
+   4. elev_std_9x9                        0.0419
+   5. twi_100m                            0.0323
+   6. soil_clay_pct_0_5cm                 0.0285
+   7. aspect                              0.0275
+   8. soil_clay_pct_15_30cm               0.0258
+   9. tpi_11x11                           0.0258
+  10. slope_std_9x9                       0.0255
+  11. slope_5x5_std_dev                   0.0253
+  12. soil_organic_matter_5_15cm          0.0252
+  13. soil_organic_matter_15_30cm         0.0241
+  14. soil_clay_pct_5_15cm                0.0232
+  15. twi_10m                             0.0228
+  16. soil_ksat_0_5cm                     0.0218
+  17. soil_ksat_5_15cm                    0.0217
+  18. soil_organic_matter_0_5cm           0.0216
+  19. dd_h                                0.0211
+  20. soil_ksat_15_30cm                   0.0204
+  21. curvature_plan                      0.0183
+  22. dd_s                                0.0177
+  23. tri                                 0.0176
+  24. slope                               0.0172
+  25. elev_std_3x3                        0.0157
+  26. elev_5x5_rel                        0.0139
+  27. curvature_profile                   0.0123
+  28. tpi_3x3                             0.0113
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  122,729
+  Estimated meadow area:        1,227.29 ha
+  Total valid pixels:           2,147,013
+  Meadow coverage:              5.72%
+
+PIPELINE RUNTIME
+  Total time: 9m 30s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Winchuck_River_log.txt
+++ b/GEE/TIF_Output/Logs/Winchuck_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Winchuck_River
+Date/Time: 2026-04-29 16:37:21
+================================================================================
+
+DATA SUMMARY
+  Total samples:           14,140
+  Wetland (1):             2,828  (20.0%)
+  Non-wetland (0):         11,312  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            10,605
+  Test set:                3,535
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9983
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9979
+  Accuracy:                0.9881
+
+  Wetland:
+    Precision:             0.9624
+    Recall:                0.9788
+    F1-score:              0.9705
+    Support:               707
+
+  Non-Wetland:
+    Precision:             0.9947
+    Recall:                0.9905
+    F1-score:              0.9926
+    Support:               2,828
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                 2,801                27
+  Actual Wetland                  15               692
+
+FEATURE IMPORTANCES (ranked)
+   1. tri                                 0.6353
+   2. elev_std_9x9                        0.1853
+   3. dd_v                                0.0330
+   4. elev_std_3x3                        0.0125
+   5. dd_s                                0.0125
+   6. twi_100m                            0.0106
+   7. tpi_21x21                           0.0101
+   8. tpi_11x11                           0.0095
+   9. curvature_plan                      0.0095
+  10. soil_clay_pct_15_30cm               0.0090
+  11. soil_ksat_15_30cm                   0.0073
+  12. slope_5x5_std_dev                   0.0071
+  13. soil_clay_pct_5_15cm                0.0063
+  14. soil_ksat_0_5cm                     0.0058
+  15. elev_5x5_std_dev                    0.0054
+  16. soil_organic_matter_15_30cm         0.0047
+  17. soil_organic_matter_0_5cm           0.0040
+  18. soil_ksat_5_15cm                    0.0039
+  19. soil_organic_matter_5_15cm          0.0038
+  20. slope_std_9x9                       0.0037
+  21. aspect                              0.0036
+  22. elev_5x5_rel                        0.0033
+  23. soil_clay_pct_0_5cm                 0.0031
+  24. tpi_3x3                             0.0028
+  25. dd_h                                0.0024
+  26. twi_10m                             0.0022
+  27. slope                               0.0016
+  28. curvature_profile                   0.0016
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  28,262
+  Estimated meadow area:        282.62 ha
+  Total valid pixels:           1,849,948
+  Meadow coverage:              1.53%
+
+PIPELINE RUNTIME
+  Total time: 9m 29s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Wood_River_log.txt
+++ b/GEE/TIF_Output/Logs/Wood_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Wood_River
+Date/Time: 2026-04-29 16:37:51
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9887
+  colsample_bytree          0.8
+  gamma                     0.5
+  learning_rate             0.1
+  max_depth                 6
+  min_child_weight          5
+  n_estimators              100
+  random_state              42
+  reg_alpha                 0
+  reg_lambda                1.5
+  scale_pos_weight          4.0
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9909
+  Accuracy:                0.9675
+
+  Wetland:
+    Precision:             0.8727
+    Recall:                0.9806
+    F1-score:              0.9235
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9950
+    Recall:                0.9643
+    F1-score:              0.9794
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,285               715
+  Actual Wetland                  97             4,903
+
+FEATURE IMPORTANCES (ranked)
+   1. soil_ksat_0_5cm                     0.4470
+   2. soil_ksat_5_15cm                    0.2816
+   3. elev_std_9x9                        0.0964
+   4. soil_clay_pct_15_30cm               0.0353
+   5. tri                                 0.0266
+   6. soil_clay_pct_5_15cm                0.0246
+   7. soil_clay_pct_0_5cm                 0.0219
+   8. soil_ksat_15_30cm                   0.0081
+   9. elev_5x5_std_dev                    0.0068
+  10. dd_v                                0.0050
+  11. slope_std_9x9                       0.0049
+  12. soil_organic_matter_0_5cm           0.0048
+  13. elev_std_3x3                        0.0039
+  14. soil_organic_matter_5_15cm          0.0032
+  15. soil_organic_matter_15_30cm         0.0032
+  16. slope_5x5_std_dev                   0.0030
+  17. tpi_21x21                           0.0026
+  18. twi_100m                            0.0026
+  19. aspect                              0.0026
+  20. elev_5x5_rel                        0.0021
+  21. slope                               0.0020
+  22. tpi_3x3                             0.0020
+  23. dd_s                                0.0019
+  24. twi_10m                             0.0019
+  25. tpi_11x11                           0.0017
+  26. dd_h                                0.0016
+  27. curvature_plan                      0.0015
+  28. curvature_profile                   0.0013
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  1,347,344
+  Estimated meadow area:        13,473.44 ha
+  Total valid pixels:           4,903,239
+  Meadow coverage:              27.48%
+
+PIPELINE RUNTIME
+  Total time: 10m 0s
+
+================================================================================

--- a/GEE/TIF_Output/Logs/Yreka_Creek_Shasta_River_log.txt
+++ b/GEE/TIF_Output/Logs/Yreka_Creek_Shasta_River_log.txt
@@ -1,0 +1,87 @@
+================================================================================
+WATERSHED: Yreka_Creek_Shasta_River
+Date/Time: 2026-04-29 16:37:21
+================================================================================
+
+DATA SUMMARY
+  Total samples:           100,000
+  Wetland (1):             20,000  (20.0%)
+  Non-wetland (0):         80,000  (80.0%)
+  Class ratio (neg/pos):   4.00
+  Training set:            75,000
+  Test set:                25,000
+
+HYPERPARAMETERS (tuned (per-watershed))
+  best_cv_auc               0.9518
+  colsample_bytree          1.0
+  gamma                     0
+  learning_rate             0.2
+  max_depth                 8
+  min_child_weight          3
+  n_estimators              300
+  random_state              42
+  reg_alpha                 0.5
+  reg_lambda                2.0
+  scale_pos_weight          4.0
+  subsample                 1.0
+
+TEST SET PERFORMANCE
+  AUC:                     0.9842
+  Accuracy:                0.9526
+
+  Wetland:
+    Precision:             0.8613
+    Recall:                0.9092
+    F1-score:              0.8846
+    Support:               5,000
+
+  Non-Wetland:
+    Precision:             0.9770
+    Recall:                0.9634
+    F1-score:              0.9701
+    Support:               20,000
+
+CONFUSION MATRIX
+                       Predicted Non-W  Predicted Wetland
+  Actual Non-W                19,268               732
+  Actual Wetland                 454             4,546
+
+FEATURE IMPORTANCES (ranked)
+   1. elev_std_9x9                        0.2424
+   2. soil_organic_matter_15_30cm         0.1330
+   3. dd_v                                0.0550
+   4. tpi_21x21                           0.0526
+   5. twi_100m                            0.0379
+   6. soil_ksat_0_5cm                     0.0379
+   7. slope_std_9x9                       0.0278
+   8. soil_clay_pct_15_30cm               0.0273
+   9. slope                               0.0272
+  10. soil_ksat_15_30cm                   0.0252
+  11. curvature_plan                      0.0244
+  12. soil_ksat_5_15cm                    0.0242
+  13. dd_h                                0.0241
+  14. tri                                 0.0231
+  15. soil_clay_pct_0_5cm                 0.0223
+  16. aspect                              0.0223
+  17. elev_5x5_std_dev                    0.0212
+  18. soil_organic_matter_0_5cm           0.0210
+  19. soil_organic_matter_5_15cm          0.0201
+  20. dd_s                                0.0199
+  21. slope_5x5_std_dev                   0.0166
+  22. twi_10m                             0.0160
+  23. elev_std_3x3                        0.0160
+  24. soil_clay_pct_5_15cm                0.0154
+  25. tpi_11x11                           0.0150
+  26. curvature_profile                   0.0127
+  27. elev_5x5_rel                        0.0100
+  28. tpi_3x3                             0.0095
+PREDICTION STATISTICS
+  Meadow pixels (prob > 0.5):  149,011
+  Estimated meadow area:        1,490.11 ha
+  Total valid pixels:           3,208,950
+  Meadow coverage:              4.64%
+
+PIPELINE RUNTIME
+  Total time: 9m 32s
+
+================================================================================


### PR DESCRIPTION
Adds training logs for all 119 watersheds from the no-elevation pipeline run.

Logs include per-watershed AUC, precision, recall, F1, confusion matrix, feature importances, and pipeline runtime.

Also unignores `GEE/TIF_Output/Logs/` in `.gitignore` so future runs are tracked automatically.